### PR TITLE
onceUsingId() not always return boolean

### DIFF
--- a/src/Tymon/JWTAuth/JWTAuth.php
+++ b/src/Tymon/JWTAuth/JWTAuth.php
@@ -1,5 +1,6 @@
 <?php namespace Tymon\JWTAuth;
 
+use Exception;
 use Tymon\JWTAuth\Providers\ProviderInterface;
 use Tymon\JWTAuth\Exceptions\JWTAuthException;
 use Illuminate\Auth\AuthManager;
@@ -111,8 +112,9 @@ class JWTAuth {
 
 		$id = $this->provider->getSubject($this->token);
 
-		if (! $this->auth->onceUsingId($id) )
-		{
+		try {
+			$this->auth->onceUsingId($id);
+		} catch (Exception $e) {
 			return false;
 		}
 


### PR DESCRIPTION
`Illuminate\Auth\Guard::onceUsingId() ` not always return boolean，when the user id in the token does not exist or has been deleted will cause an exception:

https://github.com/laravel/framework/blob/4.2/src/Illuminate/Auth/Guard.php#L482

if `$this->provider->retrieveById($id)` return null;

then https://github.com/laravel/framework/blob/4.2/src/Illuminate/Auth/Guard.php#L682 Will throw an exception：

```shell
Argument 1 passed to Illuminate\Auth\Guard::setUser() must implement interface Illuminate\Auth\UserInterface, null given, called in xxxxxxx/vendor/laravel/framework/src/Illuminate/Auth/Guard.php on line 482 and defined
```
