### PR TITLE
We have to return the user

### DIFF
--- a/src/Providers/User/EloquentUserAdapter.php
+++ b/src/Providers/User/EloquentUserAdapter.php
@@ -30,6 +30,6 @@ class EloquentUserAdapter implements UserInterface
      */
     public function getBy($key, $value)
     {
-        $this->user->where($key, $value)->first();
+        return $this->user->where($key, $value)->first();
     }
 }


### PR DESCRIPTION
Hey,

this is my first pull request on GitHub, so maybe I am doing it wrong. :-)

I like your package and I would use it in one of my projects, but I noticed that it doesn't work as expected. But if you return the user in the EloquentUserAdapter like so, everything works fine for me. So I can do:

$token = JWTAuth::getToken();
$user = JWTAuth::toUser($token);

And have accesss to the User. Great!

Looking forward to the updates and thank you for the package!

Regards,
Thomas

PS: Would it be possible to just have a method JWTAuth::getUser() which will return the user without having to get the token first?