### PR TITLE
Fix requireToken()

### DIFF
--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -264,7 +264,7 @@ class JWTAuth
      */
     protected function requireToken($token)
     {
-        if (! $token && ! $this->token) {
+        if (! $token = $token ?: $this->token) {
             throw new JWTException('A token is required', 400);
         }
 


### PR DESCRIPTION
Right now method chaining doesn't work, e.g. you can't do the following:
```
$user = JWTAuth::parseToken()->toUser();
// will throw TokenInvalidException('Wrong number of segments');
```
`JWTAuth::parseToken()` will set the token property in JWTAuth class to the token in the header. If we chain `->toUser()` the requireToken() method will not throw an exception as there is a token set to the object, but in the end we just pass in the $token (which is false) to setToken(). Therefore, throwing an TokenInvalidException('Wrong number of segments').

The change should enable that we can chain these methods.