### PR TITLE
Bug Fix for Refresh Token middleware raising 'Token is Blacklisted' erro...

### DIFF
--- a/src/Middleware/RefreshToken.php
+++ b/src/Middleware/RefreshToken.php
@@ -16,15 +16,16 @@ class RefreshToken extends BaseMiddleware
      */
     public function handle($request, \Closure $next)
     {
-        try {
+
+        $response = $next($request);
+        
+         try {
             $newToken = $this->auth->setRequest($request)->parseToken()->refresh();
         } catch (TokenExpiredException $e) {
             return $this->respond('tymon.jwt.expired', 'token_expired', $e->getStatusCode(), [$e]);
         } catch (JWTException $e) {
             return $this->respond('tymon.jwt.invalid', 'token_invalid', $e->getStatusCode(), [$e]);
         }
-
-        $response = $next($request);
 
         // send the refreshed token back to the client
         $response->headers->set('Authorization', 'Bearer ' . $newToken);


### PR DESCRIPTION
...r.

It was creating a new token and invalidating the current request token before processing the request. So by the time 'after middleware' kicks in, its current token is already invalid. This fix is all it needs.