### PR TITLE
clone new jwt provider without auth for lumen

### DIFF
--- a/src/Facades/JWT.php
+++ b/src/Facades/JWT.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tymon\JWTAuth\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class JWT extends Facade
+{
+  /**
+   * Get the registered name of the component.
+   *
+   * @return string
+   */
+  protected static function getFacadeAccessor()
+  {
+    return 'tymon.jwt';
+  }
+}

--- a/src/Facades/JWT.php
+++ b/src/Facades/JWT.php
@@ -6,13 +6,13 @@ use Illuminate\Support\Facades\Facade;
 
 class JWT extends Facade
 {
-  /**
-   * Get the registered name of the component.
-   *
-   * @return string
-   */
-  protected static function getFacadeAccessor()
-  {
-    return 'tymon.jwt';
-  }
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'tymon.jwt';
+    }
 }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -7,241 +7,241 @@ use Tymon\JWTAuth\Exceptions\JWTException;
 
 class JWT
 {
-  /**
-   * @var \Tymon\JWTAuth\JWTManager
-   */
-  protected $manager;
+    /**
+     * @var \Tymon\JWTAuth\JWTManager
+     */
+    protected $manager;
 
-  /**
-   * @var \Illuminate\Http\Request
-   */
-  protected $request;
+    /**
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
 
-  /**
-   * @var string
-   */
-  protected $identifier = 'id';
+    /**
+     * @var string
+     */
+    protected $identifier = 'id';
 
-  /**
-   * @var \Tymon\JWTAuth\Token
-   */
-  protected $token;
+    /**
+     * @var \Tymon\JWTAuth\Token
+     */
+    protected $token;
 
-  /**
-   * @param \Tymon\JWTAuth\JWTManager $manager
-   * @param \Illuminate\Http\Request $request
-   */
-  public function __construct(JWTManager $manager, Request $request)
-  {
-    $this->manager = $manager;
-    $this->request = $request;
-  }
-
-  /**
-   * Refresh an expired token.
-   *
-   * @param mixed $token
-   *
-   * @return string
-   */
-  public function refresh($token = FALSE)
-  {
-    $this->requireToken($token);
-
-    return $this->manager->refresh($this->token)->get();
-  }
-
-  /**
-   * Invalidate a token (add it to the blacklist).
-   *
-   * @param mixed $token
-   *
-   * @return boolean
-   */
-  public function invalidate($token = FALSE)
-  {
-    $this->requireToken($token);
-
-    return $this->manager->invalidate($this->token);
-  }
-
-  /**
-   * Get the token.
-   *
-   * @return boolean|string
-   */
-  public function getToken()
-  {
-    if ( ! $this->token) {
-      try {
-        $this->parseToken();
-      } catch (JWTException $e) {
-        return FALSE;
-      }
+    /**
+     * @param \Tymon\JWTAuth\JWTManager $manager
+     * @param \Illuminate\Http\Request $request
+     */
+    public function __construct(JWTManager $manager, Request $request)
+    {
+        $this->manager = $manager;
+        $this->request = $request;
     }
 
-    return $this->token;
-  }
+    /**
+     * Refresh an expired token.
+     *
+     * @param mixed $token
+     *
+     * @return string
+     */
+    public function refresh($token = FALSE)
+    {
+        $this->requireToken($token);
 
-  /**
-   * Get the raw Payload instance.
-   *
-   * @param mixed $token
-   *
-   * @return \Tymon\JWTAuth\Payload
-   */
-  public function getPayload($token = FALSE)
-  {
-    $this->requireToken($token);
-
-    return $this->manager->decode($this->token);
-  }
-
-  /**
-   * Parse the token from the request.
-   *
-   * @param string $query
-   *
-   * @return JWTAuth
-   */
-  public function parseToken($method = 'bearer', $header = 'authorization', $query = 'token')
-  {
-    if ( ! $token = $this->parseAuthHeader($header, $method)) {
-      if ( ! $token = $this->request->query($query, FALSE)) {
-        throw new JWTException('The token could not be parsed from the request', 400);
-      }
+        return $this->manager->refresh($this->token)->get();
     }
 
-    return $this->setToken($token);
-  }
+    /**
+     * Invalidate a token (add it to the blacklist).
+     *
+     * @param mixed $token
+     *
+     * @return boolean
+     */
+    public function invalidate($token = FALSE)
+    {
+        $this->requireToken($token);
 
-  /**
-   * Parse token from the authorization header.
-   *
-   * @param string $header
-   * @param string $method
-   *
-   * @return false|string
-   */
-  protected function parseAuthHeader($header = 'authorization', $method = 'bearer')
-  {
-    $header = $this->request->headers->get($header);
-
-    if ( ! starts_with(strtolower($header), $method)) {
-      return FALSE;
+        return $this->manager->invalidate($this->token);
     }
 
-    return trim(str_ireplace($method, '', $header));
-  }
+    /**
+     * Get the token.
+     *
+     * @return boolean|string
+     */
+    public function getToken()
+    {
+        if (!$this->token) {
+            try {
+                $this->parseToken();
+            } catch (JWTException $e) {
+                return FALSE;
+            }
+        }
 
-  /**
-   * Create a Payload instance.
-   *
-   * @param mixed $subject
-   * @param array $customClaims
-   *
-   * @return \Tymon\JWTAuth\Payload
-   */
-  protected function makePayload($subject, array $customClaims = [])
-  {
-    return $this->manager->getPayloadFactory()->make(
-      array_merge($customClaims, ['sub' => $subject])
-    );
-  }
-
-  /**
-   * Set the identifier.
-   *
-   * @param string $identifier
-   * @return $this
-   */
-  public function setIdentifier($identifier)
-  {
-    $this->identifier = $identifier;
-
-    return $this;
-  }
-
-  /**
-   * Get the identifier.
-   *
-   * @return string
-   */
-  public function getIdentifier()
-  {
-    return $this->identifier;
-  }
-
-  /**
-   * Set the token.
-   *
-   * @param string $token
-   *
-   * @return $this
-   */
-  public function setToken($token)
-  {
-    $this->token = new Token($token);
-
-    return $this;
-  }
-
-  /**
-   * Ensure that a token is available.
-   *
-   * @param mixed $token
-   *
-   * @return JWTAuth
-   *
-   * @throws \Tymon\JWTAuth\Exceptions\JWTException
-   */
-  protected function requireToken($token)
-  {
-    if ( ! $token = $token ?: $this->token) {
-      throw new JWTException('A token is required', 400);
+        return $this->token;
     }
 
-    return $this->setToken($token);
-  }
+    /**
+     * Get the raw Payload instance.
+     *
+     * @param mixed $token
+     *
+     * @return \Tymon\JWTAuth\Payload
+     */
+    public function getPayload($token = FALSE)
+    {
+        $this->requireToken($token);
 
-  /**
-   * Set the request instance.
-   *
-   * @param Request $request
-   */
-  public function setRequest(Request $request)
-  {
-    $this->request = $request;
-
-    return $this;
-  }
-
-  /**
-   * Get the JWTManager instance.
-   *
-   * @return \Tymon\JWTAuth\JWTManager
-   */
-  public function manager()
-  {
-    return $this->manager;
-  }
-
-  /**
-   * Magically call the JWT Manager.
-   *
-   * @param string $method
-   * @param array $parameters
-   *
-   * @return mixed
-   *
-   * @throws \BadMethodCallException
-   */
-  public function __call($method, $parameters)
-  {
-    if (method_exists($this->manager, $method)) {
-      return call_user_func_array([$this->manager, $method], $parameters);
+        return $this->manager->decode($this->token);
     }
 
-    throw new \BadMethodCallException("Method [$method] does not exist.");
-  }
+    /**
+     * Parse the token from the request.
+     *
+     * @param string $query
+     *
+     * @return JWTAuth
+     */
+    public function parseToken($method = 'bearer', $header = 'authorization', $query = 'token')
+    {
+        if (!$token = $this->parseAuthHeader($header, $method)) {
+            if (!$token = $this->request->query($query, FALSE)) {
+                throw new JWTException('The token could not be parsed from the request', 400);
+            }
+        }
+
+        return $this->setToken($token);
+    }
+
+    /**
+     * Parse token from the authorization header.
+     *
+     * @param string $header
+     * @param string $method
+     *
+     * @return false|string
+     */
+    protected function parseAuthHeader($header = 'authorization', $method = 'bearer')
+    {
+        $header = $this->request->headers->get($header);
+
+        if (!starts_with(strtolower($header), $method)) {
+            return FALSE;
+        }
+
+        return trim(str_ireplace($method, '', $header));
+    }
+
+    /**
+     * Create a Payload instance.
+     *
+     * @param mixed $subject
+     * @param array $customClaims
+     *
+     * @return \Tymon\JWTAuth\Payload
+     */
+    protected function makePayload($subject, array $customClaims = [])
+    {
+        return $this->manager->getPayloadFactory()->make(
+            array_merge($customClaims, ['sub' => $subject])
+        );
+    }
+
+    /**
+     * Set the identifier.
+     *
+     * @param string $identifier
+     * @return $this
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
+    /**
+     * Get the identifier.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the token.
+     *
+     * @param string $token
+     *
+     * @return $this
+     */
+    public function setToken($token)
+    {
+        $this->token = new Token($token);
+
+        return $this;
+    }
+
+    /**
+     * Ensure that a token is available.
+     *
+     * @param mixed $token
+     *
+     * @return JWTAuth
+     *
+     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     */
+    protected function requireToken($token)
+    {
+        if (!$token = $token ?: $this->token) {
+            throw new JWTException('A token is required', 400);
+        }
+
+        return $this->setToken($token);
+    }
+
+    /**
+     * Set the request instance.
+     *
+     * @param Request $request
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+
+        return $this;
+    }
+
+    /**
+     * Get the JWTManager instance.
+     *
+     * @return \Tymon\JWTAuth\JWTManager
+     */
+    public function manager()
+    {
+        return $this->manager;
+    }
+
+    /**
+     * Magically call the JWT Manager.
+     *
+     * @param string $method
+     * @param array $parameters
+     *
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (method_exists($this->manager, $method)) {
+            return call_user_func_array([$this->manager, $method], $parameters);
+        }
+
+        throw new \BadMethodCallException("Method [$method] does not exist.");
+    }
 }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -44,7 +44,7 @@ class JWT
      *
      * @return string
      */
-    public function refresh($token = FALSE)
+    public function refresh($token = false)
     {
         $this->requireToken($token);
 
@@ -58,7 +58,7 @@ class JWT
      *
      * @return boolean
      */
-    public function invalidate($token = FALSE)
+    public function invalidate($token = false)
     {
         $this->requireToken($token);
 
@@ -76,7 +76,7 @@ class JWT
             try {
                 $this->parseToken();
             } catch (JWTException $e) {
-                return FALSE;
+                return false;
             }
         }
 
@@ -90,7 +90,7 @@ class JWT
      *
      * @return \Tymon\JWTAuth\Payload
      */
-    public function getPayload($token = FALSE)
+    public function getPayload($token = false)
     {
         $this->requireToken($token);
 
@@ -107,7 +107,7 @@ class JWT
     public function parseToken($method = 'bearer', $header = 'authorization', $query = 'token')
     {
         if (!$token = $this->parseAuthHeader($header, $method)) {
-            if (!$token = $this->request->query($query, FALSE)) {
+            if (!$token = $this->request->query($query, false)) {
                 throw new JWTException('The token could not be parsed from the request', 400);
             }
         }
@@ -128,7 +128,7 @@ class JWT
         $header = $this->request->headers->get($header);
 
         if (!starts_with(strtolower($header), $method)) {
-            return FALSE;
+            return false;
         }
 
         return trim(str_ireplace($method, '', $header));

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Tymon\JWTAuth;
+
+use Illuminate\Http\Request;
+use Tymon\JWTAuth\Exceptions\JWTException;
+
+class JWT
+{
+  /**
+   * @var \Tymon\JWTAuth\JWTManager
+   */
+  protected $manager;
+
+  /**
+   * @var \Illuminate\Http\Request
+   */
+  protected $request;
+
+  /**
+   * @var string
+   */
+  protected $identifier = 'id';
+
+  /**
+   * @var \Tymon\JWTAuth\Token
+   */
+  protected $token;
+
+  /**
+   * @param \Tymon\JWTAuth\JWTManager $manager
+   * @param \Illuminate\Http\Request $request
+   */
+  public function __construct(JWTManager $manager, Request $request)
+  {
+    $this->manager = $manager;
+    $this->request = $request;
+  }
+
+  /**
+   * Refresh an expired token.
+   *
+   * @param mixed $token
+   *
+   * @return string
+   */
+  public function refresh($token = FALSE)
+  {
+    $this->requireToken($token);
+
+    return $this->manager->refresh($this->token)->get();
+  }
+
+  /**
+   * Invalidate a token (add it to the blacklist).
+   *
+   * @param mixed $token
+   *
+   * @return boolean
+   */
+  public function invalidate($token = FALSE)
+  {
+    $this->requireToken($token);
+
+    return $this->manager->invalidate($this->token);
+  }
+
+  /**
+   * Get the token.
+   *
+   * @return boolean|string
+   */
+  public function getToken()
+  {
+    if ( ! $this->token) {
+      try {
+        $this->parseToken();
+      } catch (JWTException $e) {
+        return FALSE;
+      }
+    }
+
+    return $this->token;
+  }
+
+  /**
+   * Get the raw Payload instance.
+   *
+   * @param mixed $token
+   *
+   * @return \Tymon\JWTAuth\Payload
+   */
+  public function getPayload($token = FALSE)
+  {
+    $this->requireToken($token);
+
+    return $this->manager->decode($this->token);
+  }
+
+  /**
+   * Parse the token from the request.
+   *
+   * @param string $query
+   *
+   * @return JWTAuth
+   */
+  public function parseToken($method = 'bearer', $header = 'authorization', $query = 'token')
+  {
+    if ( ! $token = $this->parseAuthHeader($header, $method)) {
+      if ( ! $token = $this->request->query($query, FALSE)) {
+        throw new JWTException('The token could not be parsed from the request', 400);
+      }
+    }
+
+    return $this->setToken($token);
+  }
+
+  /**
+   * Parse token from the authorization header.
+   *
+   * @param string $header
+   * @param string $method
+   *
+   * @return false|string
+   */
+  protected function parseAuthHeader($header = 'authorization', $method = 'bearer')
+  {
+    $header = $this->request->headers->get($header);
+
+    if ( ! starts_with(strtolower($header), $method)) {
+      return FALSE;
+    }
+
+    return trim(str_ireplace($method, '', $header));
+  }
+
+  /**
+   * Create a Payload instance.
+   *
+   * @param mixed $subject
+   * @param array $customClaims
+   *
+   * @return \Tymon\JWTAuth\Payload
+   */
+  protected function makePayload($subject, array $customClaims = [])
+  {
+    return $this->manager->getPayloadFactory()->make(
+      array_merge($customClaims, ['sub' => $subject])
+    );
+  }
+
+  /**
+   * Set the identifier.
+   *
+   * @param string $identifier
+   * @return $this
+   */
+  public function setIdentifier($identifier)
+  {
+    $this->identifier = $identifier;
+
+    return $this;
+  }
+
+  /**
+   * Get the identifier.
+   *
+   * @return string
+   */
+  public function getIdentifier()
+  {
+    return $this->identifier;
+  }
+
+  /**
+   * Set the token.
+   *
+   * @param string $token
+   *
+   * @return $this
+   */
+  public function setToken($token)
+  {
+    $this->token = new Token($token);
+
+    return $this;
+  }
+
+  /**
+   * Ensure that a token is available.
+   *
+   * @param mixed $token
+   *
+   * @return JWTAuth
+   *
+   * @throws \Tymon\JWTAuth\Exceptions\JWTException
+   */
+  protected function requireToken($token)
+  {
+    if ( ! $token = $token ?: $this->token) {
+      throw new JWTException('A token is required', 400);
+    }
+
+    return $this->setToken($token);
+  }
+
+  /**
+   * Set the request instance.
+   *
+   * @param Request $request
+   */
+  public function setRequest(Request $request)
+  {
+    $this->request = $request;
+
+    return $this;
+  }
+
+  /**
+   * Get the JWTManager instance.
+   *
+   * @return \Tymon\JWTAuth\JWTManager
+   */
+  public function manager()
+  {
+    return $this->manager;
+  }
+
+  /**
+   * Magically call the JWT Manager.
+   *
+   * @param string $method
+   * @param array $parameters
+   *
+   * @return mixed
+   *
+   * @throws \BadMethodCallException
+   */
+  public function __call($method, $parameters)
+  {
+    if (method_exists($this->manager, $method)) {
+      return call_user_func_array([$this->manager, $method], $parameters);
+    }
+
+    throw new \BadMethodCallException("Method [$method] does not exist.");
+  }
+}

--- a/src/Providers/JWT/JWTProvider.php
+++ b/src/Providers/JWT/JWTProvider.php
@@ -15,8 +15,8 @@ abstract class JWTProvider
     protected $algo;
 
     /**
-     * @param string  $secret
-     * @param string  $algo
+     * @param string $secret
+     * @param string $algo
      */
     public function __construct($secret, $algo = 'HS256')
     {
@@ -27,7 +27,7 @@ abstract class JWTProvider
     /**
      * Set the algorithm used to sign the token
      *
-     * @param  string  $algo
+     * @param  string $algo
      * @return self
      */
     public function setAlgo($algo)

--- a/src/Providers/JWTServiceProvider.php
+++ b/src/Providers/JWTServiceProvider.php
@@ -18,7 +18,7 @@ class JWTServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = FALSE;
+    protected $defer = false;
 
     /**
      * Boot the service provider.
@@ -212,7 +212,7 @@ class JWTServiceProvider extends ServiceProvider
      * @param  string $key
      * @return string
      */
-    protected function config($key, $default = NULL)
+    protected function config($key, $default = null)
     {
         return config("jwt.$key", $default);
     }

--- a/src/Providers/JWTServiceProvider.php
+++ b/src/Providers/JWTServiceProvider.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tymon\JWTAuth\Providers;
+
+use Tymon\JWTAuth\JWT;
+use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\JWTManager;
+use Tymon\JWTAuth\PayloadFactory;
+use Tymon\JWTAuth\Claims\Factory;
+use Illuminate\Support\ServiceProvider;
+use Tymon\JWTAuth\Commands\JWTGenerateCommand;
+use Tymon\JWTAuth\Validators\PayloadValidator;
+
+class JWTServiceProvider extends ServiceProvider
+{
+  /**
+   * Indicates if loading of the provider is deferred.
+   *
+   * @var bool
+   */
+  protected $defer = FALSE;
+
+  /**
+   * Boot the service provider.
+   */
+  public function boot()
+  {
+
+    $this->publishes([
+      __DIR__ . '/../config/config.php' => $this->app->basePath('config') . '/jwt.php'
+    ], 'config');
+
+    $this->bootBindings();
+
+    $this->commands('tymon.jwt.generate');
+  }
+
+  /**
+   * Bind some Interfaces and implementations
+   */
+  protected function bootBindings()
+  {
+    $this->app['Tymon\JWTAuth\JWT'] = function ($app) {
+      return $app['tymon.jwt'];
+    };
+
+    $this->app['Tymon\JWTAuth\Providers\JWT\JWTInterface'] = function ($app) {
+      return $app['tymon.jwt.provider.jwt'];
+    };
+
+    $this->app['Tymon\JWTAuth\Providers\Storage\StorageInterface'] = function ($app) {
+      return $app['tymon.jwt.provider.storage'];
+    };
+
+    $this->app['Tymon\JWTAuth\JWTManager'] = function ($app) {
+      return $app['tymon.jwt.manager'];
+    };
+
+    $this->app['Tymon\JWTAuth\Blacklist'] = function ($app) {
+      return $app['tymon.jwt.blacklist'];
+    };
+
+    $this->app['Tymon\JWTAuth\PayloadFactory'] = function ($app) {
+      return $app['tymon.jwt.payload.factory'];
+    };
+
+    $this->app['Tymon\JWTAuth\Claims\Factory'] = function ($app) {
+      return $app['tymon.jwt.claim.factory'];
+    };
+
+    $this->app['Tymon\JWTAuth\Validators\PayloadValidator'] = function ($app) {
+      return $app['tymon.jwt.validators.payload'];
+    };
+  }
+
+  /**
+   * Register the service provider.
+   *
+   * @return void
+   */
+  public function register()
+  {
+    // register providers
+    $this->registerJWTProvider();
+    $this->registerStorageProvider();
+    $this->registerJWTBlacklist();
+
+    $this->registerClaimFactory();
+    $this->registerJWTManager();
+
+    $this->registerJWT();
+    $this->registerPayloadValidator();
+    $this->registerPayloadFactory();
+    $this->registerJWTCommand();
+
+    $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'jwt');
+  }
+
+  /**
+   * Register the bindings for the JSON Web Token provider
+   */
+  protected function registerJWTProvider()
+  {
+    $this->app['tymon.jwt.provider.jwt'] = $this->app->share(function ($app) {
+
+      $secret = $this->config('secret');
+      $algo = $this->config('algo');
+      $provider = $this->config('providers.jwt');
+
+      return $app->make($provider, [$secret, $algo]);
+    });
+  }
+
+  /**
+   * Register the bindings for the Storage provider
+   */
+  protected function registerStorageProvider()
+  {
+    $this->app['tymon.jwt.provider.storage'] = $this->app->share(function ($app) {
+      return $this->getConfigInstance($this->config('providers.storage'));
+    });
+  }
+
+  /**
+   * Register the bindings for the Payload Factory
+   */
+  protected function registerClaimFactory()
+  {
+    $this->app->singleton('tymon.jwt.claim.factory', function () {
+      return new Factory();
+    });
+  }
+
+  /**
+   * Register the bindings for the JWT Manager
+   */
+  protected function registerJWTManager()
+  {
+    $this->app['tymon.jwt.manager'] = $this->app->share(function ($app) {
+
+      $instance = new JWTManager(
+        $app['tymon.jwt.provider.jwt'],
+        $app['tymon.jwt.blacklist'],
+        $app['tymon.jwt.payload.factory']
+      );
+
+      return $instance->setBlacklistEnabled((bool) $this->config('blacklist_enabled'));
+    });
+  }
+
+  /**
+   * Register the bindings for the main JWTAuth class
+   */
+  protected function registerJWT()
+  {
+    $this->app['tymon.jwt'] = $this->app->share(function ($app) {
+
+      $auth = new JWT(
+        $app['tymon.jwt.manager'],
+        $app['request']
+      );
+
+      return $auth->setIdentifier($this->config('identifier'));
+    });
+  }
+
+  /**
+   * Register the bindings for the main JWTAuth class
+   */
+  protected function registerJWTBlacklist()
+  {
+    $this->app['tymon.jwt.blacklist'] = $this->app->share(function ($app) {
+      return new Blacklist($app['tymon.jwt.provider.storage']);
+    });
+  }
+
+  /**
+   * Register the bindings for the payload validator
+   */
+  protected function registerPayloadValidator()
+  {
+    $this->app['tymon.jwt.validators.payload'] = $this->app->share(function () {
+      return with(new PayloadValidator())->setRequiredClaims($this->config('required_claims'));
+    });
+  }
+
+  /**
+   * Register the bindings for the Payload Factory
+   */
+  protected function registerPayloadFactory()
+  {
+    $this->app['tymon.jwt.payload.factory'] = $this->app->share(function ($app) {
+      $factory = new PayloadFactory($app['tymon.jwt.claim.factory'], $app['request'], $app['tymon.jwt.validators.payload']);
+
+      return $factory->setTTL($this->config('ttl'));
+    });
+  }
+
+  /**
+   * Register the Artisan command
+   */
+  protected function registerJWTCommand()
+  {
+    $this->app['tymon.jwt.generate'] = $this->app->share(function () {
+      return new JWTGenerateCommand();
+    });
+  }
+
+  /**
+   * Helper to get the config values
+   *
+   * @param  string $key
+   * @return string
+   */
+  protected function config($key, $default = NULL)
+  {
+    return config("jwt.$key", $default);
+  }
+
+  /**
+   * Get an instantiable configuration instance. Pinched from dingo/api :)
+   *
+   * @param  mixed $instance
+   * @return object
+   */
+  protected function getConfigInstance($instance)
+  {
+    if (is_callable($instance)) {
+      return call_user_func($instance, $this->app);
+    } elseif (is_string($instance)) {
+      return $this->app->make($instance);
+    }
+
+    return $instance;
+  }
+}

--- a/src/Providers/JWTServiceProvider.php
+++ b/src/Providers/JWTServiceProvider.php
@@ -25,7 +25,6 @@ class JWTServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
         $this->publishes([
             __DIR__ . '/../config/config.php' => $this->app->basePath('config') . '/jwt.php'
         ], 'config');

--- a/src/Providers/JWTServiceProvider.php
+++ b/src/Providers/JWTServiceProvider.php
@@ -13,224 +13,224 @@ use Tymon\JWTAuth\Validators\PayloadValidator;
 
 class JWTServiceProvider extends ServiceProvider
 {
-  /**
-   * Indicates if loading of the provider is deferred.
-   *
-   * @var bool
-   */
-  protected $defer = FALSE;
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = FALSE;
 
-  /**
-   * Boot the service provider.
-   */
-  public function boot()
-  {
+    /**
+     * Boot the service provider.
+     */
+    public function boot()
+    {
 
-    $this->publishes([
-      __DIR__ . '/../config/config.php' => $this->app->basePath('config') . '/jwt.php'
-    ], 'config');
+        $this->publishes([
+            __DIR__ . '/../config/config.php' => $this->app->basePath('config') . '/jwt.php'
+        ], 'config');
 
-    $this->bootBindings();
+        $this->bootBindings();
 
-    $this->commands('tymon.jwt.generate');
-  }
-
-  /**
-   * Bind some Interfaces and implementations
-   */
-  protected function bootBindings()
-  {
-    $this->app['Tymon\JWTAuth\JWT'] = function ($app) {
-      return $app['tymon.jwt'];
-    };
-
-    $this->app['Tymon\JWTAuth\Providers\JWT\JWTInterface'] = function ($app) {
-      return $app['tymon.jwt.provider.jwt'];
-    };
-
-    $this->app['Tymon\JWTAuth\Providers\Storage\StorageInterface'] = function ($app) {
-      return $app['tymon.jwt.provider.storage'];
-    };
-
-    $this->app['Tymon\JWTAuth\JWTManager'] = function ($app) {
-      return $app['tymon.jwt.manager'];
-    };
-
-    $this->app['Tymon\JWTAuth\Blacklist'] = function ($app) {
-      return $app['tymon.jwt.blacklist'];
-    };
-
-    $this->app['Tymon\JWTAuth\PayloadFactory'] = function ($app) {
-      return $app['tymon.jwt.payload.factory'];
-    };
-
-    $this->app['Tymon\JWTAuth\Claims\Factory'] = function ($app) {
-      return $app['tymon.jwt.claim.factory'];
-    };
-
-    $this->app['Tymon\JWTAuth\Validators\PayloadValidator'] = function ($app) {
-      return $app['tymon.jwt.validators.payload'];
-    };
-  }
-
-  /**
-   * Register the service provider.
-   *
-   * @return void
-   */
-  public function register()
-  {
-    // register providers
-    $this->registerJWTProvider();
-    $this->registerStorageProvider();
-    $this->registerJWTBlacklist();
-
-    $this->registerClaimFactory();
-    $this->registerJWTManager();
-
-    $this->registerJWT();
-    $this->registerPayloadValidator();
-    $this->registerPayloadFactory();
-    $this->registerJWTCommand();
-
-    $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'jwt');
-  }
-
-  /**
-   * Register the bindings for the JSON Web Token provider
-   */
-  protected function registerJWTProvider()
-  {
-    $this->app['tymon.jwt.provider.jwt'] = $this->app->share(function ($app) {
-
-      $secret = $this->config('secret');
-      $algo = $this->config('algo');
-      $provider = $this->config('providers.jwt');
-
-      return $app->make($provider, [$secret, $algo]);
-    });
-  }
-
-  /**
-   * Register the bindings for the Storage provider
-   */
-  protected function registerStorageProvider()
-  {
-    $this->app['tymon.jwt.provider.storage'] = $this->app->share(function ($app) {
-      return $this->getConfigInstance($this->config('providers.storage'));
-    });
-  }
-
-  /**
-   * Register the bindings for the Payload Factory
-   */
-  protected function registerClaimFactory()
-  {
-    $this->app->singleton('tymon.jwt.claim.factory', function () {
-      return new Factory();
-    });
-  }
-
-  /**
-   * Register the bindings for the JWT Manager
-   */
-  protected function registerJWTManager()
-  {
-    $this->app['tymon.jwt.manager'] = $this->app->share(function ($app) {
-
-      $instance = new JWTManager(
-        $app['tymon.jwt.provider.jwt'],
-        $app['tymon.jwt.blacklist'],
-        $app['tymon.jwt.payload.factory']
-      );
-
-      return $instance->setBlacklistEnabled((bool) $this->config('blacklist_enabled'));
-    });
-  }
-
-  /**
-   * Register the bindings for the main JWTAuth class
-   */
-  protected function registerJWT()
-  {
-    $this->app['tymon.jwt'] = $this->app->share(function ($app) {
-
-      $auth = new JWT(
-        $app['tymon.jwt.manager'],
-        $app['request']
-      );
-
-      return $auth->setIdentifier($this->config('identifier'));
-    });
-  }
-
-  /**
-   * Register the bindings for the main JWTAuth class
-   */
-  protected function registerJWTBlacklist()
-  {
-    $this->app['tymon.jwt.blacklist'] = $this->app->share(function ($app) {
-      return new Blacklist($app['tymon.jwt.provider.storage']);
-    });
-  }
-
-  /**
-   * Register the bindings for the payload validator
-   */
-  protected function registerPayloadValidator()
-  {
-    $this->app['tymon.jwt.validators.payload'] = $this->app->share(function () {
-      return with(new PayloadValidator())->setRequiredClaims($this->config('required_claims'));
-    });
-  }
-
-  /**
-   * Register the bindings for the Payload Factory
-   */
-  protected function registerPayloadFactory()
-  {
-    $this->app['tymon.jwt.payload.factory'] = $this->app->share(function ($app) {
-      $factory = new PayloadFactory($app['tymon.jwt.claim.factory'], $app['request'], $app['tymon.jwt.validators.payload']);
-
-      return $factory->setTTL($this->config('ttl'));
-    });
-  }
-
-  /**
-   * Register the Artisan command
-   */
-  protected function registerJWTCommand()
-  {
-    $this->app['tymon.jwt.generate'] = $this->app->share(function () {
-      return new JWTGenerateCommand();
-    });
-  }
-
-  /**
-   * Helper to get the config values
-   *
-   * @param  string $key
-   * @return string
-   */
-  protected function config($key, $default = NULL)
-  {
-    return config("jwt.$key", $default);
-  }
-
-  /**
-   * Get an instantiable configuration instance. Pinched from dingo/api :)
-   *
-   * @param  mixed $instance
-   * @return object
-   */
-  protected function getConfigInstance($instance)
-  {
-    if (is_callable($instance)) {
-      return call_user_func($instance, $this->app);
-    } elseif (is_string($instance)) {
-      return $this->app->make($instance);
+        $this->commands('tymon.jwt.generate');
     }
 
-    return $instance;
-  }
+    /**
+     * Bind some Interfaces and implementations
+     */
+    protected function bootBindings()
+    {
+        $this->app['Tymon\JWTAuth\JWT'] = function ($app) {
+            return $app['tymon.jwt'];
+        };
+
+        $this->app['Tymon\JWTAuth\Providers\JWT\JWTInterface'] = function ($app) {
+            return $app['tymon.jwt.provider.jwt'];
+        };
+
+        $this->app['Tymon\JWTAuth\Providers\Storage\StorageInterface'] = function ($app) {
+            return $app['tymon.jwt.provider.storage'];
+        };
+
+        $this->app['Tymon\JWTAuth\JWTManager'] = function ($app) {
+            return $app['tymon.jwt.manager'];
+        };
+
+        $this->app['Tymon\JWTAuth\Blacklist'] = function ($app) {
+            return $app['tymon.jwt.blacklist'];
+        };
+
+        $this->app['Tymon\JWTAuth\PayloadFactory'] = function ($app) {
+            return $app['tymon.jwt.payload.factory'];
+        };
+
+        $this->app['Tymon\JWTAuth\Claims\Factory'] = function ($app) {
+            return $app['tymon.jwt.claim.factory'];
+        };
+
+        $this->app['Tymon\JWTAuth\Validators\PayloadValidator'] = function ($app) {
+            return $app['tymon.jwt.validators.payload'];
+        };
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // register providers
+        $this->registerJWTProvider();
+        $this->registerStorageProvider();
+        $this->registerJWTBlacklist();
+
+        $this->registerClaimFactory();
+        $this->registerJWTManager();
+
+        $this->registerJWT();
+        $this->registerPayloadValidator();
+        $this->registerPayloadFactory();
+        $this->registerJWTCommand();
+
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'jwt');
+    }
+
+    /**
+     * Register the bindings for the JSON Web Token provider
+     */
+    protected function registerJWTProvider()
+    {
+        $this->app['tymon.jwt.provider.jwt'] = $this->app->share(function ($app) {
+
+            $secret = $this->config('secret');
+            $algo = $this->config('algo');
+            $provider = $this->config('providers.jwt');
+
+            return $app->make($provider, [$secret, $algo]);
+        });
+    }
+
+    /**
+     * Register the bindings for the Storage provider
+     */
+    protected function registerStorageProvider()
+    {
+        $this->app['tymon.jwt.provider.storage'] = $this->app->share(function ($app) {
+            return $this->getConfigInstance($this->config('providers.storage'));
+        });
+    }
+
+    /**
+     * Register the bindings for the Payload Factory
+     */
+    protected function registerClaimFactory()
+    {
+        $this->app->singleton('tymon.jwt.claim.factory', function () {
+            return new Factory();
+        });
+    }
+
+    /**
+     * Register the bindings for the JWT Manager
+     */
+    protected function registerJWTManager()
+    {
+        $this->app['tymon.jwt.manager'] = $this->app->share(function ($app) {
+
+            $instance = new JWTManager(
+                $app['tymon.jwt.provider.jwt'],
+                $app['tymon.jwt.blacklist'],
+                $app['tymon.jwt.payload.factory']
+            );
+
+            return $instance->setBlacklistEnabled((bool)$this->config('blacklist_enabled'));
+        });
+    }
+
+    /**
+     * Register the bindings for the main JWTAuth class
+     */
+    protected function registerJWT()
+    {
+        $this->app['tymon.jwt'] = $this->app->share(function ($app) {
+
+            $auth = new JWT(
+                $app['tymon.jwt.manager'],
+                $app['request']
+            );
+
+            return $auth->setIdentifier($this->config('identifier'));
+        });
+    }
+
+    /**
+     * Register the bindings for the main JWTAuth class
+     */
+    protected function registerJWTBlacklist()
+    {
+        $this->app['tymon.jwt.blacklist'] = $this->app->share(function ($app) {
+            return new Blacklist($app['tymon.jwt.provider.storage']);
+        });
+    }
+
+    /**
+     * Register the bindings for the payload validator
+     */
+    protected function registerPayloadValidator()
+    {
+        $this->app['tymon.jwt.validators.payload'] = $this->app->share(function () {
+            return with(new PayloadValidator())->setRequiredClaims($this->config('required_claims'));
+        });
+    }
+
+    /**
+     * Register the bindings for the Payload Factory
+     */
+    protected function registerPayloadFactory()
+    {
+        $this->app['tymon.jwt.payload.factory'] = $this->app->share(function ($app) {
+            $factory = new PayloadFactory($app['tymon.jwt.claim.factory'], $app['request'], $app['tymon.jwt.validators.payload']);
+
+            return $factory->setTTL($this->config('ttl'));
+        });
+    }
+
+    /**
+     * Register the Artisan command
+     */
+    protected function registerJWTCommand()
+    {
+        $this->app['tymon.jwt.generate'] = $this->app->share(function () {
+            return new JWTGenerateCommand();
+        });
+    }
+
+    /**
+     * Helper to get the config values
+     *
+     * @param  string $key
+     * @return string
+     */
+    protected function config($key, $default = NULL)
+    {
+        return config("jwt.$key", $default);
+    }
+
+    /**
+     * Get an instantiable configuration instance. Pinched from dingo/api :)
+     *
+     * @param  mixed $instance
+     * @return object
+     */
+    protected function getConfigInstance($instance)
+    {
+        if (is_callable($instance)) {
+            return call_user_func($instance, $this->app);
+        } elseif (is_string($instance)) {
+            return $this->app->make($instance);
+        }
+
+        return $instance;
+    }
 }


### PR DESCRIPTION
app.php register:
~~~~
$app->register('Tymon\JWTAuth\Providers\JWTServiceProvider');
~~~~
use:
~~~~
use Tymon\JWTAuth\Facades\JWT;
$payload = app('tymon.jwt.payload.factory')->sub('id')->aud('foo')->make();
$token = JWT::encode($payload);
~~~~

middleware
~~~~
...
    public function __construct(ResponseFactory $response, Dispatcher $events, JWT $jwt)
    {
        $this->jwt = $jwt;
        $this->response = $response;
        $this->events = $events;
    }
...
    public function handle($request, \Closure $next)
    {
        if (!$token = $this->jwt->setRequest($request)->getToken()) {
            return $this->respond('tymon.jwt.absent', 'token_not_provided', 400);
        }

        try {
            $payload = $this->jwt->decode($token);
             //your auth
        } catch (TokenExpiredException $e) {
            return $this->respond('tymon.jwt.expired', 'token_expired', $e->getStatusCode(), [$e]);
        } catch (JWTException $e) {
            return $this->respond('tymon.jwt.invalid', 'token_invalid', $e->getStatusCode(), [$e]);
        }
...
~~~~
