### PR TITLE
Fix issue causing auth refresh to fail

### DIFF
--- a/tests/JWTManagerTest.php
+++ b/tests/JWTManagerTest.php
@@ -68,7 +68,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
         $token = new Token('foo.bar.baz');
 
         $this->jwt->shouldReceive('decode')->once()->with('foo.bar.baz')->andReturn($payload->toArray());
-        $this->factory->shouldReceive('make')->with($payload->toArray())->andReturn($payload);
+        $this->factory->shouldReceive('setRefreshFlow->make')->with($payload->toArray())->andReturn($payload);
         $this->blacklist->shouldReceive('has')->with($payload)->andReturn(false);
 
         $payload = $this->manager->decode($token);
@@ -93,7 +93,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
         $token = new Token('foo.bar.baz');
 
         $this->jwt->shouldReceive('decode')->once()->with('foo.bar.baz')->andReturn($payload->toArray());
-        $this->factory->shouldReceive('make')->with($payload->toArray())->andReturn($payload);
+        $this->factory->shouldReceive('setRefreshFlow->make')->with($payload->toArray())->andReturn($payload);
         $this->blacklist->shouldReceive('has')->with($payload)->andReturn(true);
 
         $payload = $this->manager->decode($token);
@@ -143,7 +143,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
         $token = new Token('foo.bar.baz');
 
         $this->jwt->shouldReceive('decode')->once()->with('foo.bar.baz')->andReturn($payload->toArray());
-        $this->factory->shouldReceive('make')->with($payload->toArray())->andReturn($payload);
+        $this->factory->shouldReceive('setRefreshFlow->make')->with($payload->toArray())->andReturn($payload);
         $this->blacklist->shouldReceive('has')->with($payload)->andReturn(false);
 
         $this->blacklist->shouldReceive('add')->with($payload)->andReturn(true);


### PR DESCRIPTION
I had an issue where I would always get a expired token error when trying to refresh a token that is expired, but still within the refresh_ttl.

I found that the token was being validated before the refreshFlow was enabled. This pull request adds the ability to start the refresh flow before validating.

Another user encountered the same problem and created issue #101