### PR TITLE
Fixed TokenExpired response

### DIFF
--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -71,7 +71,7 @@ class PayloadValidator extends AbstractValidator
         }
 
         if (Utils::timestamp($payload['exp'])->isPast()) {
-            throw new TokenExpiredException('Token has expired', 400);
+            throw new TokenExpiredException('Token has expired');
         }
 
         return true;


### PR DESCRIPTION
The TokenExpired exception was being created with a 400 status when it should be 401.