### PR TITLE
[WIP] Added support for closures as custom claims

### DIFF
--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -81,7 +81,7 @@ class JWTAuth
      */
     public function fromUser($user, array $customClaims = [])
     {
-        $payload = $this->makePayload($user->{$this->identifier}, $customClaims);
+        $payload = $this->makePayload($user, $customClaims);
 
         return $this->manager->encode($payload)->get();
     }
@@ -221,15 +221,17 @@ class JWTAuth
     /**
      * Create a Payload instance.
      *
-     * @param mixed $subject
+     * @param mixed $user
      * @param array $customClaims
      *
      * @return \Tymon\JWTAuth\Payload
      */
-    protected function makePayload($subject, array $customClaims = [])
+    protected function makePayload($user, array $customClaims = [])
     {
+        $subject = $user->{$this->identifier};
+
         return $this->manager->getPayloadFactory()->make(
-            array_merge($customClaims, ['sub' => $subject])
+            array_merge($customClaims, ['sub' => $subject]), $user
         );
     }
 


### PR DESCRIPTION
As [my suggestion](https://github.com/tymondesigns/jwt-auth/issues/89#issuecomment-97771027) to fix #89, it makes possible to pass closures as Custom Claims, with the User as the first argument:

```php
$customClaims = [
    'regular' => 'A regular claim',
    'role' => function($user) {
        return $user->role;
    },
];

$token = JWTAuth::attempt($credentials, $customClaims);
```

## Work in progress:
- [X] Basic support
- [X] Support for callables
- [ ] Write some tests