### PR TITLE
Permit to pass custom claims to the refresh method

### DIFF
--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -135,7 +135,7 @@ class JWTAuth
     {
         $this->requireToken($token);
 
-        return $this->manager->refresh($this->token, $customClaims = [])->get();
+        return $this->manager->refresh($this->token, $customClaims)->get();
     }
 
     /**

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -126,13 +126,16 @@ class JWTAuth
      *
      * @param mixed $token
      *
+     * @param array $customClaims
+     *
+     * @throws JWTException
      * @return string
      */
-    public function refresh($token = false)
+    public function refresh($token = false, $customClaims = [])
     {
         $this->requireToken($token);
 
-        return $this->manager->refresh($this->token)->get();
+        return $this->manager->refresh($this->token, $customClaims = [])->get();
     }
 
     /**

--- a/src/JWTManager.php
+++ b/src/JWTManager.php
@@ -81,10 +81,13 @@ class JWTManager
     /**
      * Refresh a Token and return a new Token
      *
-     * @param  \Tymon\JWTAuth\Token  $token
+     * @param  \Tymon\JWTAuth\Token $token
+     * @param array                 $customClaims
+     *
+     * @throws TokenBlacklistedException
      * @return \Tymon\JWTAuth\Token
      */
-    public function refresh(Token $token)
+    public function refresh(Token $token, $customClaims = [])
     {
         $payload = $this->setRefreshFlow()->decode($token);
 
@@ -95,10 +98,13 @@ class JWTManager
 
         // return the new token
         return $this->encode(
-            $this->payloadFactory->make([
+            $this->payloadFactory->make(
+              array_merge([
                 'sub' => $payload['sub'],
                 'iat' => $payload['iat']
-            ])
+                ],
+                $customClaims )
+            )
         );
     }
 


### PR DESCRIPTION
I need to change the `is` claim also on the refresh method and it was to complicated, by passing the custom claims directly to the method as second parameter its possible.