### PR TITLE
bumped namshi/jose to 5.0: tokens are now interoperable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "~5.0",
         "illuminate/http": "~5.0",
-        "namshi/jose": "2.2.*",
+        "namshi/jose": "5.0.*",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {

--- a/src/Providers/JWT/NamshiAdapter.php
+++ b/src/Providers/JWT/NamshiAdapter.php
@@ -23,7 +23,7 @@ class NamshiAdapter extends JWTProvider implements JWTInterface
     {
         parent::__construct($secret, $algo);
 
-        $this->jws = $driver ?: new JWS($algo);
+        $this->jws = $driver ?: new JWS(['alg' => $algo]);
     }
 
     /**


### PR DESCRIPTION
This is a follow up to a patch I did on namshi/jose. The encoding for the token signature was slightly wrong, so tokens weren't language interoperable.
