### PR TITLE
Fixes security related bug in RefreshToken middleware

### DIFF
--- a/src/Middleware/RefreshToken.php
+++ b/src/Middleware/RefreshToken.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of jwt-auth
- *
- * (c) Sean Tymon <tymon148@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Tymon\JWTAuth\Middleware;
 
 use Tymon\JWTAuth\Exceptions\JWTException;
@@ -21,12 +12,10 @@ class RefreshToken extends BaseMiddleware
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     *
      * @return mixed
      */
     public function handle($request, \Closure $next)
     {
-        $response = $next($request);
 
         try {
             $newToken = $this->auth->setRequest($request)->parseToken()->refresh();
@@ -36,6 +25,8 @@ class RefreshToken extends BaseMiddleware
             return $this->respond('tymon.jwt.invalid', 'token_invalid', $e->getStatusCode(), [$e]);
         }
 
+        $response = $next($request);
+        
         // send the refreshed token back to the client
         $response->headers->set('Authorization', 'Bearer ' . $newToken);
 


### PR DESCRIPTION
Fixes security related bug

I was about to use the middleware as authorization middleware when I realized that it inside it is implemented as an after middleware. If I am not totally wrong that means that any request to a related route also those without authorization header will call the related controller action (and for example update or delete a resource) before the requester is told not being allowed to do so.

I didn't write any functional tests (because I didn't find any which test if unauthorized users are blocked properly from doing forbidden things) but you get the idea.

If you don't think that this issue is a problem and the RefreshToken should be kept as is, it is fine for me. But I'd suggest then to update the wiki to let users know about the risk when using the RefreshToken middleware without the GetUserFromToken middleware.

Btw. jwt-auth is a great Laravel extension