### PR TITLE
Fix issues with blacklisting expired tokens and refreshing blacklisted tokens

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -30,6 +30,13 @@ class Blacklist
     protected $gracePeriod = 0;
 
     /**
+     * Number of minutes from issue date in which a JWT can be refreshed.
+     *
+     * @var integer
+     */
+    protected $refreshTTL = 20160;
+
+    /**
      * @param \Tymon\JWTAuth\Contracts\Providers\Storage  $storage
      */
     public function __construct(Storage $storage)
@@ -122,6 +129,20 @@ class Blacklist
     public function setGracePeriod($gracePeriod)
     {
         $this->gracePeriod = (int) $gracePeriod;
+
+        return $this;
+    }
+
+    /**
+     * Set the refresh time limit
+     *
+     * @param  integer
+     *
+     * @return Blacklist
+     */
+    public function setRefreshTTL($gracePeriod)
+    {
+        $this->refreshTTL = $ttl;
 
         return $this;
     }

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -60,7 +60,7 @@ class Blacklist
         // find the number of minutes until the expiration date, plus 1 minute to avoid overlap
         $minutes = $lastExp->diffInMinutes(Utils::now()->subMinute());
 
-        $this->storage->add($payload['jti'], ['valid_until' => $this->getGraceTimestamp()], $minutes);
+        $this->storage->add($payload['jti'], ['valid_until' => $this->getGraceTimestamp(Carbon::now())], $minutes);
 
         return true;
     }
@@ -74,10 +74,10 @@ class Blacklist
      */
     public function has(Payload $payload)
     {
-        $grace = $this->storage->get($payload['jti']);
+        $id = $this->storage->get($payload['jti']);
 
         // check whether the expiry + grace has past
-        if (is_null($grace) || Utils::timestamp($grace['valid_until'])->isFuture()) {
+        if (is_null($id) || Utils::timestamp($grace['valid_until'])->isFuture()) {
             return false;
         }
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -74,10 +74,10 @@ class Blacklist
      */
     public function has(Payload $payload)
     {
-        $id = $this->storage->get($payload['jti']);
+        $grace = $this->storage->get($payload['jti']);
 
         // check whether the expiry + grace has past
-        if (is_null($id) || Utils::timestamp($grace['valid_until'])->isFuture()) {
+        if (is_null($grace) || Utils::timestamp($grace['valid_until'])->isFuture()) {
             return false;
         }
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -142,7 +142,7 @@ class Blacklist
      *
      * @return Blacklist
      */
-    public function setRefreshTTL($gracePeriod)
+    public function setRefreshTTL($ttl)
     {
         $this->refreshTTL = $ttl;
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -54,9 +54,12 @@ class Blacklist
     public function add(Payload $payload)
     {
         $exp = Utils::timestamp($payload['exp']);
+        $refreshExp = Utils::timestamp($payload['iat'])->addMinute($this->refreshTTL);
 
         // add a minute to abate potential overlap
-        $minutes = $exp->diffInMinutes(Utils::now()->subMinute());
+        $minutesUntilExp = $exp->diffInMinutes(Utils::now()->subMinute());
+        $minutesUntilNoRefresh = $refreshExp->diffInMinutes(Utils::now()->subMinute());
+        $minutes = max($minutesUntilExp, $minutesUntilNoRefresh);
 
         $this->storage->add($payload['jti'], ['valid_until' => $this->getGraceTimestamp($exp)], $minutes);
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -55,12 +55,12 @@ class Blacklist
     {
         $exp = Utils::timestamp($payload['exp']);
         $refreshExp = Utils::timestamp($payload['iat'])->addMinute($this->refreshTTL);
-        $latestExp = $exp->max($refreshExp); // the later of the two expiration dates
+        $lastExp = $exp->max($refreshExp); // the later of the two expiration dates
 
         // find the number of minutes until the expiration date, plus 1 minute to avoid overlap
-        $minutes = $laterExp->diffInMinutes(Utils::now()->subMinute());
+        $minutes = $lastExp->diffInMinutes(Utils::now()->subMinute());
 
-        $this->storage->add($payload['jti'], ['valid_until' => $this->getGraceTimestamp($latestExp)], $minutes);
+        $this->storage->add($payload['jti'], ['valid_until' => $this->getGraceTimestamp()], $minutes);
 
         return true;
     }

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -12,8 +12,8 @@
 namespace Tymon\JWTAuth;
 
 use Carbon\Carbon;
-use Tymon\JWTAuth\Support\Utils;
 use Tymon\JWTAuth\Contracts\Providers\Storage;
+use Tymon\JWTAuth\Support\Utils;
 
 class Blacklist
 {
@@ -47,12 +47,6 @@ class Blacklist
     public function add(Payload $payload)
     {
         $exp = Utils::timestamp($payload['exp']);
-
-        // there is no need to add the token to the blacklist
-        // if it has already expired
-        if ($exp->isPast()) {
-            return false;
-        }
 
         // add a minute to abate potential overlap
         $minutes = $exp->diffInMinutes(Utils::now()->subMinute());

--- a/src/Providers/LumenServiceProvider.php
+++ b/src/Providers/LumenServiceProvider.php
@@ -147,7 +147,8 @@ class LumenServiceProvider extends ServiceProvider
         $this->app->singleton('tymon.jwt.blacklist', function ($app) {
             $instance = new Blacklist($app['tymon.jwt.provider.storage']);
 
-            return $instance->setGracePeriod($this->config('blacklist_grace_period'));
+            return $instance->setGracePeriod($this->config('blacklist_grace_period'))
+                            ->setRefreshTTL($this->config('refresh_ttl'));
         });
     }
 

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -57,7 +57,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator);
 
-        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => 3723], 61)->once();
+        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => 3723], 20161)->once();
         $this->blacklist->add($payload);
     }
 
@@ -74,7 +74,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator, true);
 
-        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => -3477], 59)->once();
+        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => -3477], 20161)->once();
         $this->assertTrue($this->blacklist->add($payload));
     }
 

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -12,6 +12,7 @@
 namespace Tymon\JWTAuth\Test;
 
 use Mockery;
+use Carbon\Carbon;
 use Tymon\JWTAuth\Blacklist;
 use Tymon\JWTAuth\Payload;
 use Tymon\JWTAuth\Claims\Issuer;
@@ -28,6 +29,8 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        Carbon::setTestNow(Carbon::createFromTimeStampUTC(123));
+
         $this->storage = Mockery::mock('Tymon\JWTAuth\Contracts\Providers\Storage');
         $this->blacklist = new Blacklist($this->storage);
 
@@ -37,6 +40,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
+        Carbon::setTestNow();
         Mockery::close();
     }
 
@@ -53,7 +57,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator);
 
-        $this->storage->shouldReceive('add')->with('foo', [], 61);
+        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => 3723], 61)->once();
         $this->blacklist->add($payload);
     }
 
@@ -87,8 +91,8 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator);
 
-        $this->storage->shouldReceive('has')->with('foobar')->andReturn(true);
-        $this->storage->shouldReceive('get')->with('foobar')->andReturn(['valid_until' => 3723 + 0]);
+        $this->storage->shouldReceive('has')->with('foobar')->once()->andReturn(true);
+        $this->storage->shouldReceive('get')->with('foobar')->once()->andReturn(['valid_until' => 3723 + 0]);
 
         $this->assertTrue($this->blacklist->has($payload));
     }

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -57,7 +57,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator);
 
-        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => 3723], 20161)->once();
+        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => 123], 20161)->once();
         $this->blacklist->add($payload);
     }
 
@@ -74,7 +74,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator, true);
 
-        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => -3477], 20161)->once();
+        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => 123], 20161)->once();
         $this->assertTrue($this->blacklist->add($payload));
     }
 
@@ -92,7 +92,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         $payload = new Payload(Collection::make($claims), $this->validator);
 
         $this->storage->shouldReceive('has')->with('foobar')->once()->andReturn(true);
-        $this->storage->shouldReceive('get')->with('foobar')->once()->andReturn(['valid_until' => 3723 + 0]);
+        $this->storage->shouldReceive('get')->with('foobar')->once()->andReturn(['valid_until' => 123]);
 
         $this->assertTrue($this->blacklist->has($payload));
     }

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -58,7 +58,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_should_return_false_when_adding_an_expired_token_to_the_blacklist()
+    public function it_should_return_true_when_adding_an_expired_token_to_the_blacklist()
     {
         $claims = [
             'sub' => new Subject(1),
@@ -70,8 +70,8 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator, true);
 
-        $this->storage->shouldReceive('add')->never();
-        $this->assertFalse($this->blacklist->add($payload));
+        $this->storage->shouldReceive('add')->with('foo', ['valid_until' => -3477], 59)->once();
+        $this->assertTrue($this->blacklist->add($payload));
     }
 
     /** @test */

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -91,7 +91,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload(Collection::make($claims), $this->validator);
 
-        $this->storage->shouldReceive('has')->with('foobar')->once()->andReturn(true);
+        $this->storage->shouldReceive('has')->with('foobar')->andReturn(true); // currently unused
         $this->storage->shouldReceive('get')->with('foobar')->once()->andReturn(['valid_until' => 123]);
 
         $this->assertTrue($this->blacklist->has($payload));


### PR DESCRIPTION
Fixes #143; blacklisting now **immediately** invalidates a token, regardless of expiry status, addressing a number of small issues:

* Expired tokens were just being ignored, preventing refreshable tokens from being blacklisted.
* Grace period was starting at a token's expiry date, so `blacklist->has()` would often return false for blacklisted tokens that hadn't reached their `exp` claim. Grace period now starts at time of blacklisting.
* Storage time had only extended until a token's expiration date, so depending on storage provider, entries may be cleared, allowing post-expiry tokens to sometimes become refreshable again. Entry storage time now extends to the expiry date or `iat + refesh_ttl`, whichever is later.
* Some fixes for expected time behavior and enforcing number of method calls to strengthen Blacklist unit tests.

This definitely needs some eyes & outside testing, but I wanted to put it up for consideration before heading home for the day. ;)  The new cases might also merit some extra unit tests.

There's probably also some important discussion to be had about whether anyone was relying on the old behavior (the grace period setting in particular?).