### PR TITLE
Two minor fixes for applying default claims

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -118,7 +118,7 @@ class Factory
     protected function buildClaims()
     {
         // add any custom claims first
-        $this->addClaims(array_diff_key($this->customClaims, $this->defaultClaims));
+        $this->addClaims($this->customClaims);
 
         // add the default claims
         foreach ($this->defaultClaims as $claim) {

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -231,9 +231,9 @@ class JWTAuth
     protected function getClaimsArray(JWTSubject $user)
     {
         return array_merge(
+            ['sub' => $user->getJWTIdentifier()],
             $this->customClaims,
-            $user->getJWTCustomClaims(),
-            ['sub' => $user->getJWTIdentifier()]
+            $user->getJWTCustomClaims()
         );
     }
 


### PR DESCRIPTION
* In `JWTAuth::getClaimsArray`, the subject claim retrieved from `$user->getJWTIdentified()` was taking the highest priority. IMO, if someone decides to set the subject as a custom claim, their decision should be respected. (It's a weird case, but I think it's preferable to having an inconsistency in the general rule of custom claims trumping default claims.)

* In `Factory::buildClaims`, two lefts were making a right: The removed `array_diff_key` did nothing (the custom claims are `claimName => value` while the default claims are `[auto-index] => claimName`, so they would never match). But presumably the code that would've handled the removed cases got factored out somewhere along the way, as all that remains is the code adding missing defaults. I figured it was easiest to leave the flow as is and just remove the unnecessary call.