### PR TITLE
Update Illuminate.php

### DIFF
--- a/src/Providers/Storage/Illuminate.php
+++ b/src/Providers/Storage/Illuminate.php
@@ -12,7 +12,7 @@
 namespace Tymon\JWTAuth\Providers\Storage;
 
 use Tymon\JWTAuth\Contracts\Providers\Storage;
-use Illuminate\Contracts\Cache\Store as StoreContract;
+use Illuminate\Contracts\Cache\Factory as CacheContract;
 
 class Illuminate implements Storage
 {
@@ -27,9 +27,9 @@ class Illuminate implements Storage
     protected $tag = 'tymon.jwt';
 
     /**
-     * @param \Illuminate\Contracts\Cache\Store  $cache
+     * @param \Illuminate\Contracts\Cache\Factory  $cache
      */
-    public function __construct(StoreContract $cache)
+    public function __construct(CacheContract $cache)
     {
         $this->cache = $cache;
     }


### PR DESCRIPTION
https://github.com/tymondesigns/jwt-auth/pull/266/files#diff-88ca2a8abeee0348b45b056ceee81f0fR15
----
Did you tested it? Laravel cannot instatiate Cache\Store contract.
CacheManager is an implementation of Cache\Factory contract, so this class should be use instead of Cache\Store.

In my opinion laravel Managers are so flexible, so there's no need to use contracts in this case (jwt packages allows custom cache/auth provider classes).
