### PR TITLE
Fixes typehint based on comment by @mod3st

### DIFF
--- a/src/Providers/Storage/Illuminate.php
+++ b/src/Providers/Storage/Illuminate.php
@@ -12,12 +12,12 @@
 namespace Tymon\JWTAuth\Providers\Storage;
 
 use Tymon\JWTAuth\Contracts\Providers\Storage;
-use Illuminate\Contracts\Cache\Store as StoreContract;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class Illuminate implements Storage
 {
     /**
-     * @var \Illuminate\Contracts\Cache\Store
+     * @var \Illuminate\Contracts\Cache\Repository
      */
     protected $cache;
 
@@ -27,9 +27,9 @@ class Illuminate implements Storage
     protected $tag = 'tymon.jwt';
 
     /**
-     * @param \Illuminate\Contracts\Cache\Store  $cache
+     * @param \Illuminate\Contracts\Cache\Repository  $cache
      */
-    public function __construct(StoreContract $cache)
+    public function __construct(CacheContract $cache)
     {
         $this->cache = $cache;
     }
@@ -85,7 +85,7 @@ class Illuminate implements Storage
     /**
      * Return the cache instance with tags attached
      *
-     * @return \Illuminate\Contracts\Cache\Store
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function cache()
     {

--- a/tests/Providers/Storage/IlluminateTest.php
+++ b/tests/Providers/Storage/IlluminateTest.php
@@ -18,7 +18,7 @@ class IlluminateTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->cache = Mockery::mock('Illuminate\Contracts\Cache\Store');
+        $this->cache = Mockery::mock('Illuminate\Contracts\Cache\Repository');
         $this->storage = new Storage($this->cache);
 
         $this->cache->shouldReceive('tags')->andReturn(Mockery::self());


### PR DESCRIPTION
Made a mistake there since we actually looking for a class that can
resolved to `cache.store` alias. Laravel can resolve with
`Illuminate\Cache\Repository` or `Illuminate\Contracts\Cache\Repository`
while Lumen can only resolve with
`Illuminate\Contracts\Cache\Repository`

https://github.com/laravel/framework/blob/5.1/src/Illuminate/Foundation/Application.php#L1035
https://github.com/laravel/lumen-framework/blob/5.1/src/Application.php#L1659

Signed-off-by: crynobone <crynobone@gmail.com>