### PR TITLE
numeric values for exp nbf iat claims in payload

### DIFF
--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -149,7 +149,7 @@ class PayloadFactory
      */
     public function iat()
     {
-        return Utils::now()->format('U');
+        return (int) Utils::now()->format('U');
     }
 
     /**
@@ -159,7 +159,7 @@ class PayloadFactory
      */
     public function exp()
     {
-        return Utils::now()->addMinutes($this->ttl)->format('U');
+        return (int) Utils::now()->addMinutes($this->ttl)->format('U');
     }
 
     /**
@@ -169,7 +169,7 @@ class PayloadFactory
      */
     public function nbf()
     {
-        return Utils::now()->format('U');
+        return (int) Utils::now()->format('U');
     }
 
     /**

--- a/tests/PayloadFactoryTest.php
+++ b/tests/PayloadFactoryTest.php
@@ -102,4 +102,12 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->factory->getTTL(), 12345);
     }
+
+    /** @test */
+    public function it_should_return_numeric_values_according_to_specs()
+    {
+        $this->assertInternalType('int', $this->factory->exp());
+        $this->assertInternalType('int', $this->factory->nbf());
+        $this->assertInternalType('int', $this->factory->iat());
+    }
 }


### PR DESCRIPTION
These specs suggest to use numeric values for exp-nbf-iat fields in payload.
https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.1

Some js/node packages relies on these specs and having string fields cause token rejection.
I've type casted the return value of those three claim methods.