### PR TITLE
Use array_diff to check presence of required claims

### DIFF
--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -62,7 +62,7 @@ class PayloadValidator extends Validator
      */
     protected function validateStructure(array $payload)
     {
-        if (count(array_diff_key($this->requiredClaims, array_keys($payload))) !== 0) {
+        if (count(array_diff($this->requiredClaims, array_keys($payload))) !== 0) {
             throw new TokenInvalidException('JWT payload does not contain the required claims');
         }
 


### PR DESCRIPTION
Found and fixed an issue causing the validator not to honour the "required_claims" configuration.