### PR TITLE
TokenParser should take into account route parameters

### DIFF
--- a/src/Http/TokenParser.php
+++ b/src/Http/TokenParser.php
@@ -78,13 +78,23 @@ class TokenParser
     }
 
     /**
+     * Try to get the token from the route
+     *
+     * @return false|string
+     */
+    public function fromRoute()
+    {
+        return $this->request->route()->parameter($this->query, false);
+    }
+
+    /**
      * Try to parse the token from the request query string
      *
      * @return false|string
      */
     public function fromQueryString()
     {
-        return $this->request->input($this->query, false);
+        return $this->request->input($this->query, $this->fromRoute());
     }
 
     /**


### PR DESCRIPTION
… because parsing headers and GET parameters is not enough :smirk: 