### PR TITLE
Add support for Laravel 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,25 @@ php:
   - 7.0
   - hhvm
 
+env:
+  global:
+    - laravel='*'
+
 matrix:
+  include:
+    - php: 5.6
+      env: laravel='5.1'
+    - php: 5.6
+      env: laravel='5.2'
   fast_finish: true
   allow_failures:
     - php: 7.0
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source
+  - if [[ $laravel = '*' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
+  - if [[ $laravel = '5.1' ]]; then travis_retry composer require "illuminate/contracts=5.1.*" --prefer-source --no-interaction --dev; fi
+  - if [[ $laravel = '5.2' ]]; then travis_retry composer require "illuminate/contracts=5.2.*" --prefer-source --no-interaction --dev; fi
 
 script:
   - phpunit --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,19 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.*",
-        "illuminate/http": "5.1.*",
+        "illuminate/support": "5.1.*|5.2.*",
+        "illuminate/http": "5.1.*|5.2.*",
         "namshi/jose": "6.0.*",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
         "mockery/mockery": "0.9.*",
-        "illuminate/auth": "5.1.*",
-        "illuminate/database": "5.1.*",
-        "illuminate/console": "5.1.*",
-        "cartalyst/sentinel": "2.0.*"
+        "illuminate/auth": "5.1.*|5.2.*",
+        "illuminate/database": "5.1.*|5.2.*",
+        "illuminate/console": "5.1.*|5.2.*",
+        "cartalyst/sentinel": "2.0.*",
+        "paragonie/random_compat": "~1.1"
     },
     "autoload": {
         "psr-4": {
@@ -47,5 +48,6 @@
         "branch-alias": {
             "dev-develop": "0.6-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,6 @@
             "dev-develop": "0.6-dev"
         }
     },
+    "prefer-stable": true,
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
* Add support for Laravel 5.1 and Laravel 5.2
* Update travis-ci to include test on both setup.

~~There one failing on laravel 5.1 test at the moment. I not sure how that would relate with the changes.~~