### PR TITLE
Switch to new recommended composer syntax.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.*|5.2.*",
-        "illuminate/http": "5.1.*|5.2.*",
+        "illuminate/support": "5.1.* || 5.2.*",
+        "illuminate/http": "5.1.* || 5.2.*",
         "namshi/jose": "6.0.*",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
         "mockery/mockery": "0.9.*",
-        "illuminate/auth": "5.1.*|5.2.*",
-        "illuminate/database": "5.1.*|5.2.*",
-        "illuminate/console": "5.1.*|5.2.*",
+        "illuminate/auth": "5.1.* || 5.2.*",
+        "illuminate/database": "5.1.* || 5.2.*",
+        "illuminate/console": "5.1.* || 5.2.*",
         "cartalyst/sentinel": "2.0.*"
     },
     "autoload": {


### PR DESCRIPTION
Composer now recommends to use `||` instead of just one `|`.