### PR TITLE
Provide support for tagged caches and squash L5.1.28 breakage

### DIFF
--- a/tests/Providers/Storage/IlluminateTest.php
+++ b/tests/Providers/Storage/IlluminateTest.php
@@ -14,14 +14,21 @@ namespace Tymon\JWTAuth\Test\Providers\Storage;
 use Mockery;
 use Tymon\JWTAuth\Providers\Storage\Illuminate as Storage;
 
+class TaggedStorage extends Storage {
+    // It's extremely challenging to test the actual functionality of the provider's
+    // cache() function, because it relies on calling method_exists on methods that
+    // aren't defined in the interface. Getting those conditionals to behave as expected
+    // would be a lot of finicky work compared to verifying their functionality by hand.
+    // So instead we'll just set this value manually...
+    protected $supportsTags = true;
+}
+
 class IlluminateTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
         $this->cache = Mockery::mock('Illuminate\Contracts\Cache\Repository');
         $this->storage = new Storage($this->cache);
-
-        $this->cache->shouldReceive('tags')->andReturn(Mockery::self());
     }
 
     public function tearDown()
@@ -32,7 +39,7 @@ class IlluminateTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_add_the_item_to_storage()
     {
-        $this->cache->shouldReceive('tags->put')->with('foo', 'bar', 10);
+        $this->cache->shouldReceive('put')->with('foo', 'bar', 10)->once();
 
         $this->storage->add('foo', 'bar', 10);
     }
@@ -40,7 +47,7 @@ class IlluminateTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_add_the_item_to_storage_forever()
     {
-        $this->cache->shouldReceive('tags->forever')->with('foo', 'bar');
+        $this->cache->shouldReceive('forever')->with('foo', 'bar')->once();
 
         $this->storage->forever('foo', 'bar');
     }
@@ -48,7 +55,7 @@ class IlluminateTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_get_an_item_from_storage()
     {
-        $this->cache->shouldReceive('tags->get')->with('foo')->andReturn(['foo' => 'bar']);
+        $this->cache->shouldReceive('get')->with('foo')->once()->andReturn(['foo' => 'bar']);
 
         $this->assertEquals(['foo' => 'bar'], $this->storage->get('foo'));
     }
@@ -56,7 +63,7 @@ class IlluminateTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_remove_the_item_from_storage()
     {
-        $this->cache->shouldReceive('tags->forget')->with('foo')->andReturn(true);
+        $this->cache->shouldReceive('forget')->with('foo')->once()->andReturn(true);
 
         $this->assertTrue($this->storage->destroy('foo'));
     }
@@ -64,7 +71,67 @@ class IlluminateTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_remove_all_items_from_storage()
     {
-        $this->cache->shouldReceive('flush')->withNoArgs();
+        $this->cache->shouldReceive('flush')->withNoArgs()->once();
+
+        $this->storage->flush();
+    }
+
+    // Duplicate tests for tagged storage --------------------
+
+    /**
+     * Replace the storage with our one above that overrides the tag flag, and
+     * define expectations for tags() method.
+     *
+     * @return void
+     */
+    private function emulateTags()
+    {
+        $this->storage = new TaggedStorage($this->cache);
+
+        $this->cache->shouldReceive('tags')->with('tymon.jwt')->once()->andReturn(Mockery::self());
+    }
+
+        /** @test */
+    public function it_should_add_the_item_to_tagged_storage()
+    {
+        $this->emulateTags();
+        $this->cache->shouldReceive('put')->with('foo', 'bar', 10)->once();
+
+        $this->storage->add('foo', 'bar', 10);
+    }
+
+    /** @test */
+    public function it_should_add_the_item_to_tagged_storage_forever()
+    {
+        $this->emulateTags();
+        $this->cache->shouldReceive('forever')->with('foo', 'bar')->once();
+
+        $this->storage->forever('foo', 'bar');
+    }
+
+    /** @test */
+    public function it_should_get_an_item_from_tagged_storage()
+    {
+        $this->emulateTags();
+        $this->cache->shouldReceive('get')->with('foo')->once()->andReturn(['foo' => 'bar']);
+
+        $this->assertEquals(['foo' => 'bar'], $this->storage->get('foo'));
+    }
+
+    /** @test */
+    public function it_should_remove_the_item_from_tagged_storage()
+    {
+        $this->emulateTags();
+        $this->cache->shouldReceive('forget')->with('foo')->once()->andReturn(true);
+
+        $this->assertTrue($this->storage->destroy('foo'));
+    }
+
+    /** @test */
+    public function it_should_remove_all_tagged_items_from_storage()
+    {
+        $this->emulateTags();
+        $this->cache->shouldReceive('flush')->withNoArgs()->once();
 
         $this->storage->flush();
     }


### PR DESCRIPTION
Existing checks for whether a cache supported `tags()` were quietly failing because it was handled by magical `__call` in L5.1.27 and lower. Instead of a raw method exists, this PR captures exceptions on `tags` (to handle L5.1.28) and also examine the store if a `getStore` method is available (for older releases). This fixes #367.

I also uncovered why this hadn't been caught by the tests: Using the "Demeter chain" syntax wasn't actually checking whether `tags()` was getting called, because Mockery shortcuts those checks when it knows what the output would be and only verifies the final method in the chain. Instead we separate the chain method expectations, as well as enforcing they are actually called (with `once()`) and duplicating them to have separate tests for the tagged and untagged formats.