### PR TITLE
Make route parameter parsing safer

### DIFF
--- a/src/Http/LumenRouteParams.php
+++ b/src/Http/LumenRouteParams.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of jwt-auth
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Http;
+
+use Illuminate\Http\Request;
+
+class LumenRouteParams extends RouteParams
+{
+    /**
+     * Try to get the token from the route parameters
+     *
+     * @param  \Illuminate\Http\Request
+     *
+     * @return null|string
+     */
+    public function parse(Request $request)
+    {
+        // WARNING: Only use this parser if you know what you're doing!
+        // It will only work with poorly-specified aspects of certain Lumen releases.
+        $route = $request->route();
+
+        if (! is_array($route) || ! array_has($route, '2.'.$this->key)) {
+            // Route is not the expected kind of array, or does not have a parameter
+            // with the key we want.
+            return null;
+        }
+        return $route[2][$this->key];
+    }
+}

--- a/src/Http/Parser.php
+++ b/src/Http/Parser.php
@@ -36,13 +36,35 @@ class Parser
     }
 
     /**
+     * Get the parser chain
+     *
+     * @return array The chain of ParserContracts that the parser evaluates.
+     */
+    public function getChain()
+    {
+        return $this->chain;
+    }
+
+    /**
      * Set the order of the parser chain
+     *
+     * @param array $chain
+     */
+    public function setChain(array $chain)
+    {
+        $this->chain = $chain;
+
+        return $this;
+    }
+    
+    /**
+     * Alias for setting the order of the chain
      *
      * @param array $chain
      */
     public function setChainOrder(array $chain)
     {
-        $this->chain = $chain;
+        $this->setChain($chain);
 
         return $this;
     }

--- a/src/Http/RouteParams.php
+++ b/src/Http/RouteParams.php
@@ -32,7 +32,14 @@ class RouteParams implements ParserContract
      */
     public function parse(Request $request)
     {
-        return $request->route($this->key);
+        $route = $request->route();
+        
+        if (! is_callable([$route, 'parameter'])) {
+            // Route may not be an instance of Illuminate\Routing\Route (it's an array
+            // in Lumen <5.2) or not exist at all (if the request was never dispatched)
+            return null;
+        }
+        return $route->parameter($this->key);
     }
 
     /**

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -17,6 +17,7 @@ use Tymon\JWTAuth\Http\Parser;
 use Tymon\JWTAuth\Http\AuthHeaders;
 use Tymon\JWTAuth\Http\QueryString;
 use Tymon\JWTAuth\Http\RouteParams;
+use Tymon\JWTAuth\Http\LumenRouteParams;
 
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -132,6 +133,25 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($parser->parseToken());
         $this->assertFalse($parser->hasToken());
+    }
+    
+    /** @test */
+    public function it_should_accept_lumen_request_arrays_with_special_class()
+    {
+        $request = Request::create('foo', 'GET', ['foo' => 'bar']);
+        $request->setRouteResolver(function () {
+            return [false, ['uses'=>'someController'], ['token'=>'foobar']];
+        });
+
+        $parser = new Parser($request);
+        $parser->setChainOrder([
+            new AuthHeaders,
+            new QueryString,
+            new LumenRouteParams
+        ]);
+
+        $this->assertEquals($parser->parseToken(), 'foobar');
+        $this->assertTrue($parser->hasToken());
     }
 
     /** @test */

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -153,6 +153,21 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($parser->hasToken());
     }
 
+    /** @test */
+    public function it_should_retrieve_the_chain()
+    {
+        $chain = [
+            new AuthHeaders,
+            new QueryString,
+            new RouteParams
+        ];
+
+        $parser = new Parser(Mockery::mock('Illuminate\Http\Request'));
+        $parser->setChain($chain);
+
+        $this->assertEquals($parser->getChain(), $chain);
+    }
+
     protected function getRouteMock($expectedParameterValue = null)
     {
         return Mockery::mock('Illuminate\Routing\Route')

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -97,6 +97,44 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_should_ignore_routeless_requests()
+    {
+        $request = Request::create('foo', 'GET', ['foo' => 'bar']);
+        $request->setRouteResolver(function () {
+            return null;
+        });
+
+        $parser = new Parser($request);
+        $parser->setChainOrder([
+            new AuthHeaders,
+            new QueryString,
+            new RouteParams
+        ]);
+
+        $this->assertNull($parser->parseToken());
+        $this->assertFalse($parser->hasToken());
+    }
+
+    /** @test */
+    public function it_should_ignore_lumen_request_arrays()
+    {
+        $request = Request::create('foo', 'GET', ['foo' => 'bar']);
+        $request->setRouteResolver(function () {
+            return [false, ['uses'=>'someController'], ['token'=>'foobar']];
+        });
+
+        $parser = new Parser($request);
+        $parser->setChainOrder([
+            new AuthHeaders,
+            new QueryString,
+            new RouteParams
+        ]);
+
+        $this->assertNull($parser->parseToken());
+        $this->assertFalse($parser->hasToken());
+    }
+
+    /** @test */
     public function it_should_return_null_if_no_token_in_request()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);


### PR DESCRIPTION
Added `is_callable` check for `parameter` method that was throwing fatal errors when trying to parse Lumen requests and requests that had never been dispatched, along with appropriate tests.

Also allow parsing chain to be retrieved using `JWTAuth::parser()->getChain()`, and provide a small experimental class to support unstable Lumen route params.

Addresses components of #384 & #376, and fixes #361.