### PR TITLE
Bring auth-exception-bubbling fix to 0.5

### DIFF
--- a/src/Providers/Auth/IlluminateAuthAdapter.php
+++ b/src/Providers/Auth/IlluminateAuthAdapter.php
@@ -2,7 +2,6 @@
 
 namespace Tymon\JWTAuth\Providers\Auth;
 
-use Exception;
 use Illuminate\Auth\AuthManager;
 
 class IlluminateAuthAdapter implements AuthInterface
@@ -39,11 +38,7 @@ class IlluminateAuthAdapter implements AuthInterface
      */
     public function byId($id)
     {
-        try {
-            return $this->auth->onceUsingId($id);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->auth->onceUsingId($id);
     }
 
     /**

--- a/tests/Providers/Auth/IlluminateAuthAdapterTest.php
+++ b/tests/Providers/Auth/IlluminateAuthAdapterTest.php
@@ -35,8 +35,16 @@ class IlluminateAuthAdapterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_return_false_if_user_is_not_found()
     {
-        $this->authManager->shouldReceive('onceUsingId')->once()->with(123)->andThrow(new \Exception);
+        $this->authManager->shouldReceive('onceUsingId')->once()->with(123)->andReturn(false);
         $this->assertFalse($this->auth->byId(123));
+    }
+
+    /** @test */
+    public function it_should_bubble_exceptions_from_auth()
+    {
+        $this->authManager->shouldReceive('onceUsingId')->once()->with(123)->andThrow(new \Exception('Some auth failure'));
+        $this->setExpectedException('Exception', 'Some auth failure');
+        $this->auth->byId(123);
     }
 
     /** @test */


### PR DESCRIPTION
I'm concerned that this try-catch that got removed on develop (6f7ccb7d0c28da416831fcaac27e0a4e5d242bee) is impeding debugging issues people are having on master as well, because Auth exceptions show up through the middleware there as `user_not_found`. This could be the root cause of #393 & #397 for example...