### PR TITLE
Use contracts for dispatch and response in base middleware

### DIFF
--- a/src/Middleware/BaseMiddleware.php
+++ b/src/Middleware/BaseMiddleware.php
@@ -3,18 +3,18 @@
 namespace Tymon\JWTAuth\Middleware;
 
 use Tymon\JWTAuth\JWTAuth;
-use Illuminate\Events\Dispatcher;
-use Illuminate\Routing\ResponseFactory;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Routing\ResponseFactory;
 
 abstract class BaseMiddleware
 {
     /**
-     * @var \Illuminate\Routing\ResponseFactory
+     * @var \Illuminate\Contracts\Routing\ResponseFactory
      */
     protected $response;
 
     /**
-     * @var \Illuminate\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $events;
 
@@ -26,8 +26,8 @@ abstract class BaseMiddleware
     /**
      * Create a new BaseMiddleware instance
      *
-     * @param \Illuminate\Routing\ResponseFactory  $response
-     * @param \Illuminate\Events\Dispatcher  $events
+     * @param \Illuminate\Contracts\Routing\ResponseFactory  $response
+     * @param \Illuminate\Contracts\Events\Dispatcher  $events
      * @param \Tymon\JWTAuth\JWTAuth  $auth
      */
     public function __construct(ResponseFactory $response, Dispatcher $events, JWTAuth $auth)

--- a/tests/Middleware/GetUserFromTokenTest.php
+++ b/tests/Middleware/GetUserFromTokenTest.php
@@ -11,11 +11,11 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->events = Mockery::mock('Illuminate\Events\Dispatcher');
+        $this->events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
         $this->auth = Mockery::mock('Tymon\JWTAuth\JWTAuth');
 
         $this->request = Mockery::mock('Illuminate\Http\Request');
-        $this->response = Mockery::mock('Illuminate\Routing\ResponseFactory');
+        $this->response = Mockery::mock('Illuminate\Contracts\Routing\ResponseFactory');
 
         $this->middleware = new GetUserFromToken($this->response, $this->events, $this->auth);
 


### PR DESCRIPTION
This fixes errors with class mismatch of mocked components as described in #402. There it was triggered by `$laravelTestCase->withoutEvents()` but I think there are other methods that might've had problems.

Also addresses the extremely unlikely but still valid issue of compatibility for anyone using a non-stock implementation of `Events\Dispatcher` or `Routing\ResponseFactory`. 

(Unfortunately building a test specifically for this would require including all of Laravel, because, as far as I can tell, there isn't a standalone repo that contains `Illuminate\Foundation\Testing`.)

Thanks to @kontrollanten for the diff.