### PR TITLE
Throws `JWTException` type on required token absent

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -16,6 +16,7 @@ use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Tymon\JWTAuth\Exceptions\JWTException;
 
 class JWTGuard implements Guard
 {
@@ -314,7 +315,7 @@ class JWTGuard implements Guard
     protected function requireToken()
     {
         if (! $this->jwt->getToken()) {
-            throw new BadRequestHttpException('Token could not be parsed from the request.');
+            throw new JWTException('Token could not be parsed from the request.');
         }
 
         return $this->jwt;


### PR DESCRIPTION
Current implementation is throwing a `BadRequestHttpException`.

Although I agree this is a fault on the client side that is not including the required access token when submitting the request, having `JWTGuard` throwing a package specific exception type makes it easier to intercept the exception and customize its message as needed.

Also that keeps the implementation consistent with the [examples given on the wiki](https://github.com/tymondesigns/jwt-auth/wiki/Authentication#retreiving-the-authenticated-user-from-a-token).