### PR TITLE
Add double slashes to empty exceptions

### DIFF
--- a/src/Exceptions/InvalidClaimException.php
+++ b/src/Exceptions/InvalidClaimException.php
@@ -13,4 +13,5 @@ namespace Tymon\JWTAuth\Exceptions;
 
 class InvalidClaimException extends JWTException
 {
+    //
 }

--- a/src/Exceptions/PayloadException.php
+++ b/src/Exceptions/PayloadException.php
@@ -13,4 +13,5 @@ namespace Tymon\JWTAuth\Exceptions;
 
 class PayloadException extends JWTException
 {
+    //
 }

--- a/src/Exceptions/TokenBlacklistedException.php
+++ b/src/Exceptions/TokenBlacklistedException.php
@@ -13,4 +13,5 @@ namespace Tymon\JWTAuth\Exceptions;
 
 class TokenBlacklistedException extends TokenInvalidException
 {
+    //
 }

--- a/src/Exceptions/TokenExpiredException.php
+++ b/src/Exceptions/TokenExpiredException.php
@@ -13,4 +13,5 @@ namespace Tymon\JWTAuth\Exceptions;
 
 class TokenExpiredException extends JWTException
 {
+    //
 }

--- a/src/Exceptions/TokenInvalidException.php
+++ b/src/Exceptions/TokenInvalidException.php
@@ -13,4 +13,5 @@ namespace Tymon\JWTAuth\Exceptions;
 
 class TokenInvalidException extends JWTException
 {
+    //
 }


### PR DESCRIPTION
It's more a convention than something else, meaning that the class is left empty on purpose