### PR TITLE
Disallow failure for php 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
     - php: 5.6
       env: laravel='5.2'
   fast_finish: true
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
Failure should not be allowed anymore for PHP 7.