### PR TITLE
Consistant comparison

### DIFF
--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -105,7 +105,7 @@ class PayloadValidator extends Validator
      */
     protected function validateRefresh(array $payload)
     {
-        if (isset($payload['iat']) && Utils::timestamp($payload['iat'])->diffInMinutes(Utils::now()) >= $this->refreshTTL) {
+        if (isset($payload['iat']) && Utils::timestamp($payload['iat'])->addMinutes($this->refreshTTL)->isPast()) {
             throw new TokenExpiredException('Token has expired and can no longer be refreshed');
         }
 


### PR DESCRIPTION
Remains consistant with the syntax used for `\Tymon\JWTAuth\Validators\PayloadValidator::validateTimestamps`