### PR TITLE
Allow expired-but-refreshable tokens to be blacklisted (again)

### DIFF
--- a/src/Providers/JWTAuthServiceProvider.php
+++ b/src/Providers/JWTAuthServiceProvider.php
@@ -210,7 +210,8 @@ class JWTAuthServiceProvider extends ServiceProvider
     protected function registerJWTBlacklist()
     {
         $this->app['tymon.jwt.blacklist'] = $this->app->share(function ($app) {
-            return new Blacklist($app['tymon.jwt.provider.storage']);
+            $instance =  new Blacklist($app['tymon.jwt.provider.storage']);
+            return $instance->setRefreshTTL($this->config('refresh_ttl'));
         });
     }
 

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -11,6 +11,7 @@
 
 namespace Tymon\JWTAuth\Test\Providers\JWT;
 
+use Carbon\Carbon;
 use Mockery;
 use Tymon\JWTAuth\Blacklist;
 use Tymon\JWTAuth\Payload;
@@ -27,8 +28,11 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        Carbon::setTestNow(Carbon::createFromTimeStampUTC(123));
+
         $this->storage = Mockery::mock('Tymon\JWTAuth\Providers\Storage\StorageInterface');
         $this->blacklist = new Blacklist($this->storage);
+        $this->blacklist->setRefreshTTL(20160);
 
         $this->validator = Mockery::mock('Tymon\JWTAuth\Validators\PayloadValidator');
         $this->validator->shouldReceive('setRefreshFlow->check');
@@ -45,31 +49,66 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         $claims = [
             new Subject(1),
             new Issuer('http://example.com'),
-            new Expiration(123 + 3600),
-            new NotBefore(123),
-            new IssuedAt(123),
+            new Expiration(100 + 3600),
+            new NotBefore(100),
+            new IssuedAt(100),
             new JwtId('foo')
         ];
         $payload = new Payload($claims, $this->validator);
 
-        $this->storage->shouldReceive('add')->with('foo', [], 61);
-        $this->blacklist->add($payload);
+        $this->storage->shouldReceive('add')->once()->with('foo', [], 20160);
+        $this->assertTrue($this->blacklist->add($payload));
     }
 
     /** @test */
-    public function it_should_return_false_when_adding_an_expired_token_to_the_blacklist()
+    public function it_should_return_true_when_adding_a_refreshable_expired_token_to_the_blacklist()
     {
         $claims = [
             new Subject(1),
             new Issuer('http://example.com'),
-            new Expiration(123 - 3600),
-            new NotBefore(123),
-            new IssuedAt(123),
+            new Expiration(101),
+            new NotBefore(100),
+            new IssuedAt(100),
+            new JwtId('foo')
+        ];
+        $payload = new Payload($claims, $this->validator, true);
+
+        $this->storage->shouldReceive('add')->once()->with('foo', [], 20160);
+        $this->assertTrue($this->blacklist->add($payload));
+    }
+
+    /** @test */
+    public function it_should_return_false_when_adding_an_unrefreshable_token_to_the_blacklist()
+    {
+        $claims = [
+            new Subject(1),
+            new Issuer('http://example.com'),
+            new Expiration(100), // default refresh_ttl
+            new NotBefore(100),
+            new IssuedAt(100 - 20160*60),
             new JwtId('foo')
         ];
         $payload = new Payload($claims, $this->validator, true);
 
         $this->storage->shouldReceive('add')->never();
+        $this->assertFalse($this->blacklist->add($payload));
+    }
+    
+    /** @test */
+    public function it_should_return_false_when_adding_a_unrefreshable_token_after_modifying_refresh_ttl()
+    {
+        $claims = [
+            new Subject(1),
+            new Issuer('http://example.com'),
+            new Expiration(101),
+            new NotBefore(100),
+            new IssuedAt(100),
+            new JwtId('foo')
+        ];
+        $payload = new Payload($claims, $this->validator, true);
+
+        $this->storage->shouldReceive('add')->never();
+        $this->blacklist->setRefreshTTL(0);
         $this->assertFalse($this->blacklist->add($payload));
     }
 
@@ -86,7 +125,7 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload($claims, $this->validator);
 
-        $this->storage->shouldReceive('has')->with('foobar')->andReturn(true);
+        $this->storage->shouldReceive('has')->once()->with('foobar')->andReturn(true);
         $this->assertTrue($this->blacklist->has($payload));
     }
 
@@ -103,14 +142,14 @@ class BlacklistTest extends \PHPUnit_Framework_TestCase
         ];
         $payload = new Payload($claims, $this->validator);
 
-        $this->storage->shouldReceive('destroy')->with('foobar')->andReturn(true);
+        $this->storage->shouldReceive('destroy')->once()->with('foobar')->andReturn(true);
         $this->assertTrue($this->blacklist->remove($payload));
     }
 
     /** @test */
     public function it_should_empty_the_blacklist()
     {
-        $this->storage->shouldReceive('flush');
+        $this->storage->shouldReceive('flush')->once();
         $this->assertTrue($this->blacklist->clear());
     }
 }

--- a/tests/PayloadFactoryTest.php
+++ b/tests/PayloadFactoryTest.php
@@ -11,7 +11,9 @@
 
 namespace Tymon\JWTAuth\Test\Providers\JWT;
 
+use Carbon\Carbon;
 use Mockery;
+use Tymon\JWTAuth\Utils;
 use Tymon\JWTAuth\Payload;
 use Tymon\JWTAuth\PayloadFactory;
 use Illuminate\Http\Request;
@@ -28,6 +30,8 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        Carbon::setTestNow(Carbon::createFromTimeStampUTC(123));
+
         $this->claimFactory = Mockery::mock('Tymon\JWTAuth\Claims\Factory');
         $this->validator = Mockery::mock('Tymon\JWTAuth\Validators\PayloadValidator');
         $this->factory = new PayloadFactory($this->claimFactory, Request::create('/foo', 'GET'), $this->validator);
@@ -43,13 +47,13 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->shouldReceive('setRefreshFlow->check');
 
-        $expTime = time() + 3600;
+        $expTime = 123 + 3600;
 
         $this->claimFactory->shouldReceive('get')->once()->with('sub', 1)->andReturn(new Subject(1));
         $this->claimFactory->shouldReceive('get')->once()->with('iss', Mockery::any())->andReturn(new Issuer('/foo'));
         $this->claimFactory->shouldReceive('get')->once()->with('iat', 123)->andReturn(new IssuedAt(123));
         $this->claimFactory->shouldReceive('get')->once()->with('jti', 'foo')->andReturn(new JwtId('foo'));
-        $this->claimFactory->shouldReceive('get')->once()->with('nbf', time())->andReturn(new NotBefore(time()));
+        $this->claimFactory->shouldReceive('get')->once()->with('nbf', 123)->andReturn(new NotBefore(123));
         $this->claimFactory->shouldReceive('get')->once()->with('exp', $expTime)->andReturn(new Expiration($expTime));
 
         $payload = $this->factory->make(['sub' => 1, 'jti' => 'foo', 'iat' => 123]);
@@ -68,10 +72,10 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->claimFactory->shouldReceive('get')->once()->with('sub', 1)->andReturn(new Subject(1));
         $this->claimFactory->shouldReceive('get')->once()->with('iss', Mockery::any())->andReturn(new Issuer('/foo'));
-        $this->claimFactory->shouldReceive('get')->once()->with('exp', time() + 3600)->andReturn(new Expiration(time() + 3600));
-        $this->claimFactory->shouldReceive('get')->once()->with('iat', time())->andReturn(new IssuedAt(time()));
+        $this->claimFactory->shouldReceive('get')->once()->with('exp', 123 + 3600)->andReturn(new Expiration(123 + 3600));
+        $this->claimFactory->shouldReceive('get')->once()->with('iat', 123)->andReturn(new IssuedAt(123));
         $this->claimFactory->shouldReceive('get')->once()->with('jti', Mockery::any())->andReturn(new JwtId('foo'));
-        $this->claimFactory->shouldReceive('get')->once()->with('nbf', time())->andReturn(new NotBefore(time()));
+        $this->claimFactory->shouldReceive('get')->once()->with('nbf', 123)->andReturn(new NotBefore(123));
         $this->claimFactory->shouldReceive('get')->once()->with('foo', 'baz')->andReturn(new Custom('foo', 'baz'));
 
         $payload = $this->factory->sub(1)->foo('baz')->make();
@@ -90,10 +94,10 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->claimFactory->shouldReceive('get')->once()->with('sub', 1)->andReturn(new Subject(1));
         $this->claimFactory->shouldReceive('get')->once()->with('iss', Mockery::any())->andReturn(new Issuer('/foo'));
-        $this->claimFactory->shouldReceive('get')->once()->with('exp', Mockery::any())->andReturn(new Expiration(time() + 3600));
-        $this->claimFactory->shouldReceive('get')->once()->with('iat', Mockery::any())->andReturn(new IssuedAt(time()));
+        $this->claimFactory->shouldReceive('get')->once()->with('exp', Mockery::any())->andReturn(new Expiration(123 + 3600));
+        $this->claimFactory->shouldReceive('get')->once()->with('iat', Mockery::any())->andReturn(new IssuedAt(123));
         $this->claimFactory->shouldReceive('get')->once()->with('jti', Mockery::any())->andReturn(new JwtId('foo'));
-        $this->claimFactory->shouldReceive('get')->once()->with('nbf', Mockery::any())->andReturn(new NotBefore(time()));
+        $this->claimFactory->shouldReceive('get')->once()->with('nbf', Mockery::any())->andReturn(new NotBefore(123));
         $this->claimFactory->shouldReceive('get')->once()->with('foo', ['bar' => [0, 0, 0]])->andReturn(new Custom('foo', ['bar' => [0, 0, 0]]));
 
         $payload = $this->factory->sub(1)->foo(['bar' => [0, 0, 0]])->make();

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -11,6 +11,7 @@
 
 namespace Tymon\JWTAuth\Test\Providers\JWT;
 
+use Carbon\Carbon;
 use Tymon\JWTAuth\Providers\JWT\FirebaseAdapter;
 use Tymon\JWTAuth\Payload;
 use Tymon\JWTAuth\PayloadFactory;
@@ -28,12 +29,14 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        Carbon::setTestNow(Carbon::createFromTimeStampUTC(123));
+        
         $claims = [
             new Subject(1),
             new Issuer('http://example.com'),
-            new Expiration(time() + 3600),
-            new NotBefore(time()),
-            new IssuedAt(time()),
+            new Expiration(123 + 3600),
+            new NotBefore(123),
+            new IssuedAt(123),
             new JwtId('foo')
         ];
 

--- a/tests/Providers/JWT/NamshiAdapterTest.php
+++ b/tests/Providers/JWT/NamshiAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Tymon\JWTAuth\Test\Providers\JWT;
 
+use Carbon\Carbon;
 use Mockery;
 use Illuminate\Http\Request;
 use Tymon\JWTAuth\Providers\JWT\NamshiAdapter;
@@ -19,6 +20,8 @@ class NamshiAdapterTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        Carbon::setTestNow(Carbon::createFromTimeStampUTC(123));
+        
         $this->jws = Mockery::mock('Namshi\JOSE\JWS');
         $this->provider = new NamshiAdapter('secret', 'HS256', $this->jws);
     }
@@ -31,7 +34,7 @@ class NamshiAdapterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_return_the_token_when_passing_a_valid_subject_to_encode()
     {
-        $payload = ['sub' => 1, 'exp' => time(), 'iat' => time(), 'iss' => '/foo'];
+        $payload = ['sub' => 1, 'exp' => 123, 'iat' => 123, 'iss' => '/foo'];
 
         $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
         $this->jws->shouldReceive('sign')->once()->with('secret')->andReturn(Mockery::self());
@@ -49,7 +52,7 @@ class NamshiAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->jws->shouldReceive('sign')->andThrow(new \Exception);
 
-        $payload = ['sub' => 1, 'exp' => time(), 'iat' => time(), 'iss' => '/foo'];
+        $payload = ['sub' => 1, 'exp' => 123, 'iat' => 123, 'iss' => '/foo'];
         $token = $this->provider->encode($payload);
     }
 

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Tymon\JWTAuth\Test;
 
+use Carbon\Carbon;
 use Mockery;
 use Tymon\JWTAuth\Validators\PayloadValidator;
 
@@ -18,6 +19,7 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        Carbon::setTestNow(Carbon::createFromTimeStampUTC(123));
         $this->validator = new PayloadValidator();
     }
 
@@ -26,9 +28,9 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $payload = [
             'iss' => 'http://example.com',
-            'iat' => time(),
-            'nbf' => time(),
-            'exp' => time() + 3600,
+            'iat' => 100,
+            'nbf' => 100,
+            'exp' => 100 + 3600,
             'sub' => 1,
             'jti' => 'foo'
         ];
@@ -43,9 +45,9 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
 
         $payload = [
             'iss' => 'http://example.com',
-            'iat' => time() - 3660,
-            'nbf' => time() - 3660,
-            'exp' => time() - 1440,
+            'iat' => 20,
+            'nbf' => 20,
+            'exp' => 120,
             'sub' => 1,
             'jti' => 'foo'
         ];
@@ -60,9 +62,9 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
 
         $payload = [
             'iss' => 'http://example.com',
-            'iat' => time() - 3660,
-            'nbf' => time() + 3660,
-            'exp' => time() + 1440,
+            'iat' => 100,
+            'nbf' => 150,
+            'exp' => 150 + 3600,
             'sub' => 1,
             'jti' => 'foo'
         ];
@@ -77,9 +79,9 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
 
         $payload = [
             'iss' => 'http://example.com',
-            'iat' => time() + 3660,
-            'nbf' => time() - 3660,
-            'exp' => time() + 1440,
+            'iat' => 150,
+            'nbf' => 100,
+            'exp' => 150 + 3600,
             'sub' => 1,
             'jti' => 'foo'
         ];
@@ -107,7 +109,7 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
 
         $payload = [
             'iss' => 'http://example.com',
-            'iat' => time() - 3660,
+            'iat' => 100,
             'exp' => 'foo',
             'sub' => 1,
             'jti' => 'foo'


### PR DESCRIPTION
Remake of the fix way back in #218 that I neglected to realize only ever made it to develop and not master. :dizzy_face:

Now expired-but-refreshable tokens can be blacklisted, which should fix a few refreshes people are seeing that should not succeed! Fixes #419, potentially related to some confusing situations like #378.