### PR TITLE
Fix phpdoc short descriptions

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,7 +6,6 @@ enabled:
 
 disabled:
   - concat_without_spaces
-  - phpdoc_short_description
 
 linting: true
 


### PR DESCRIPTION
They should be actual sentences so need to end in a fullstop. You should be able to merge the StyleCI changes easily yourself after this PR.