### PR TITLE
Fixing jwt:secret command

### DIFF
--- a/src/Commands/JWTGenerateSecretCommand.php
+++ b/src/Commands/JWTGenerateSecretCommand.php
@@ -23,7 +23,7 @@ class JWTGenerateSecretCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'jwt:secret {show : Simply display the key instead of modifying files.}';
+    protected $signature = 'jwt:secret {--s|show : Display the key instead of modifying files.}';
 
     /**
      * The console command description.


### PR DESCRIPTION
I apparently felt the need to live on the bleeding edge and immediately realized the jwt:secret command was broken. I would get the following exception:
`[Symfony\Component\Console\Exception\RuntimeException]  
Not enough arguments (missing: "show").`

It looks like the signature requires -- or - for commands. Changed the command to be --show and added an alias to -s. Also removed the word 'simply' to fall in line with other artisan commands.