### PR TITLE
Shouldn't token_not_provided respond a 401 ?

### DIFF
--- a/src/Middleware/GetUserFromToken.php
+++ b/src/Middleware/GetUserFromToken.php
@@ -26,7 +26,7 @@ class GetUserFromToken extends BaseMiddleware
     public function handle($request, \Closure $next)
     {
         if (! $token = $this->auth->setRequest($request)->getToken()) {
-            return $this->respond('tymon.jwt.absent', 'token_not_provided', 400);
+            return $this->respond('tymon.jwt.absent', 'token_not_provided', 401);
         }
 
         try {

--- a/tests/Middleware/GetUserFromTokenTest.php
+++ b/tests/Middleware/GetUserFromTokenTest.php
@@ -42,7 +42,7 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
         $this->auth->shouldReceive('getToken')->once()->andReturn(false);
 
         $this->events->shouldReceive('fire')->once()->with('tymon.jwt.absent', [], true);
-        $this->response->shouldReceive('json')->with(['error' => 'token_not_provided'], 400);
+        $this->response->shouldReceive('json')->with(['error' => 'token_not_provided'], 401);
 
         $this->middleware->handle($this->request, function () {});
     }


### PR DESCRIPTION
given HTTP spec, request here is not a `400 Bad Request` but a `401 Unauthorized`

see https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

What do you think ?