### PR TITLE
Use ::class notation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "october/rain": "dev-stable",
         "illuminate/console": "5.1.* || 5.2.*",
         "illuminate/database": "5.1.* || 5.2.*",
+        "illuminate/routing": "5.1.* || 5.2.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "^4.0 || ^5.0"
     },

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -43,10 +43,10 @@ class BlacklistTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->storage = Mockery::mock('Tymon\JWTAuth\Contracts\Providers\Storage');
+        $this->storage = Mockery::mock(\Tymon\JWTAuth\Contracts\Providers\Storage::class);
         $this->blacklist = new Blacklist($this->storage);
 
-        $this->validator = Mockery::mock('Tymon\JWTAuth\Validators\PayloadValidator');
+        $this->validator = Mockery::mock(\Tymon\JWTAuth\Validators\PayloadValidator::class);
         $this->validator->shouldReceive('setRefreshFlow->check');
     }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -43,8 +43,8 @@ class FactoryTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->claimFactory = Mockery::mock('Tymon\JWTAuth\Claims\Factory');
-        $this->validator = Mockery::mock('Tymon\JWTAuth\Validators\PayloadValidator');
+        $this->claimFactory = Mockery::mock(\Tymon\JWTAuth\Claims\Factory::class);
+        $this->validator = Mockery::mock(\Tymon\JWTAuth\Validators\PayloadValidator::class);
         $this->factory = new Factory($this->claimFactory, Request::create('/foo', 'GET'), $this->validator);
     }
 

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -183,7 +183,7 @@ class ParserTest extends AbstractTestCase
             new RouteParams,
         ];
 
-        $parser = new Parser(Mockery::mock('Illuminate\Http\Request'));
+        $parser = new Parser(Mockery::mock(\Illuminate\Http\Request::class));
         $parser->setChain($chain);
 
         $this->assertSame($parser->getChain(), $chain);
@@ -191,7 +191,7 @@ class ParserTest extends AbstractTestCase
 
     protected function getRouteMock($expectedParameterValue = null)
     {
-        return Mockery::mock('Illuminate\Routing\Route')
+        return Mockery::mock(\Illuminate\Routing\Route::class)
             ->shouldReceive('parameter')
             ->with('token')
             ->andReturn($expectedParameterValue)

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -38,8 +38,8 @@ class JWTAuthTest extends AbstractTestCase
     public function setUp()
     {
         $this->manager = Mockery::mock(\Tymon\JWTAuth\Manager::class);
-        $this->auth = Mockery::mock('Tymon\JWTAuth\Contracts\Providers\Auth');
-        $this->parser = Mockery::mock('Tymon\JWTAuth\Http\Parser');
+        $this->auth = Mockery::mock(\Tymon\JWTAuth\Contracts\Providers\Auth::class);
+        $this->parser = Mockery::mock(\Tymon\JWTAuth\Http\Parser::class);
 
         $this->jwtAuth = new JWTAuth($this->manager, $this->auth, $this->parser);
     }
@@ -54,7 +54,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_return_a_token_when_passing_a_user()
     {
-        $payloadFactory = Mockery::mock('Tymon\JWTAuth\Factory');
+        $payloadFactory = Mockery::mock(\Tymon\JWTAuth\Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(\Tymon\JWTAuth\Payload::class));
 
         $this->manager
@@ -73,7 +73,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_return_a_token_when_passing_valid_credentials_to_attempt_method()
     {
-        $payloadFactory = Mockery::mock('Tymon\JWTAuth\Factory');
+        $payloadFactory = Mockery::mock(\Tymon\JWTAuth\Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(\Tymon\JWTAuth\Payload::class));
 
         $this->manager

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -23,8 +23,8 @@ class JWTGuardTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->jwt = Mockery::mock('Tymon\JWTAuth\JWT');
-        $this->provider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
+        $this->jwt = Mockery::mock(\Tymon\JWTAuth\JWT::class);
+        $this->provider = Mockery::mock(\Illuminate\Contracts\Auth\UserProvider::class);
         $this->guard = new JWTGuard($this->jwt, $this->provider, Request::create('/foo', 'GET'));
     }
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -54,12 +54,12 @@ class ManagerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->jwt = Mockery::mock('Tymon\JWTAuth\Contracts\Providers\JWT');
-        $this->blacklist = Mockery::mock('Tymon\JWTAuth\Blacklist');
-        $this->factory = Mockery::mock('Tymon\JWTAuth\Factory');
+        $this->jwt = Mockery::mock(\Tymon\JWTAuth\Contracts\Providers\JWT::class);
+        $this->blacklist = Mockery::mock(\Tymon\JWTAuth\Blacklist::class);
+        $this->factory = Mockery::mock(\Tymon\JWTAuth\Factory::class);
         $this->manager = new Manager($this->jwt, $this->blacklist, $this->factory);
 
-        $this->validator = Mockery::mock('Tymon\JWTAuth\Validators\PayloadValidator');
+        $this->validator = Mockery::mock(\Tymon\JWTAuth\Validators\PayloadValidator::class);
         $this->validator->shouldReceive('setRefreshFlow->check');
     }
 

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -38,8 +38,8 @@ class AuthenticateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->auth = Mockery::mock('Tymon\JWTAuth\JWTAuth');
-        $this->request = Mockery::mock('Illuminate\Http\Request');
+        $this->auth = Mockery::mock(\Tymon\JWTAuth\JWTAuth::class);
+        $this->request = Mockery::mock(\Illuminate\Http\Request::class);
 
         $this->middleware = new Authenticate($this->auth);
     }
@@ -54,7 +54,7 @@ class AuthenticateTest extends AbstractTestCase
     /** @test */
     public function it_should_authenticate_a_user()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -71,7 +71,7 @@ class AuthenticateTest extends AbstractTestCase
      */
     public function it_should_throw_a_bad_request_exception_if_token_not_provided()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -86,7 +86,7 @@ class AuthenticateTest extends AbstractTestCase
      */
     public function it_should_throw_an_unauthorized_exception_if_token_invalid()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/Middleware/CheckTest.php
+++ b/tests/Middleware/CheckTest.php
@@ -38,8 +38,8 @@ class CheckTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->auth = Mockery::mock('Tymon\JWTAuth\JWTAuth');
-        $this->request = Mockery::mock('Illuminate\Http\Request');
+        $this->auth = Mockery::mock(\Tymon\JWTAuth\JWTAuth::class);
+        $this->request = Mockery::mock(\Illuminate\Http\Request::class);
 
         $this->middleware = new Check($this->auth);
     }
@@ -54,7 +54,7 @@ class CheckTest extends AbstractTestCase
     /** @test */
     public function it_should_authenticate_a_user_if_a_token_is_present()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -68,7 +68,7 @@ class CheckTest extends AbstractTestCase
     /** @test */
     public function it_should_unset_the_exception_if_a_token_is_present()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -82,7 +82,7 @@ class CheckTest extends AbstractTestCase
     /** @test */
     public function it_should_do_nothing_if_a_token_is_not_present()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -37,8 +37,8 @@ class RefreshTokenTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->auth = Mockery::mock('Tymon\JWTAuth\JWTAuth');
-        $this->request = Mockery::mock('Illuminate\Http\Request');
+        $this->auth = Mockery::mock(\Tymon\JWTAuth\JWTAuth::class);
+        $this->request = Mockery::mock(\Illuminate\Http\Request::class);
 
         $this->middleware = new RefreshToken($this->auth);
     }
@@ -53,7 +53,7 @@ class RefreshTokenTest extends AbstractTestCase
     /** @test */
     public function it_should_refresh_a_token()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -72,7 +72,7 @@ class RefreshTokenTest extends AbstractTestCase
      */
     public function it_should_throw_a_bad_request_exception_if_token_not_provided()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -87,7 +87,7 @@ class RefreshTokenTest extends AbstractTestCase
      */
     public function it_should_throw_an_unauthorized_exception_if_token_invalid()
     {
-        $parser = Mockery::mock('Tymon\JWTAuth\Http\TokenParser');
+        $parser = Mockery::mock(\Tymon\JWTAuth\Http\TokenParser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -47,7 +47,7 @@ class PayloadTest extends AbstractTestCase
             'jti' => new JwtId('foo'),
         ];
 
-        $this->validator = Mockery::mock('Tymon\JWTAuth\Validators\PayloadValidator');
+        $this->validator = Mockery::mock(\Tymon\JWTAuth\Validators\PayloadValidator::class);
         $this->validator->shouldReceive('setRefreshFlow->check');
 
         $this->payload = new Payload(Collection::make($claims), $this->validator);

--- a/tests/Providers/Auth/IlluminateTest.php
+++ b/tests/Providers/Auth/IlluminateTest.php
@@ -31,7 +31,7 @@ class IlluminateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->authManager = Mockery::mock('Illuminate\Contracts\Auth\Guard');
+        $this->authManager = Mockery::mock(\Illuminate\Contracts\Auth\Guard::class);
         $this->auth = new Auth($this->authManager);
     }
 

--- a/tests/Providers/Auth/OctoberTest.php
+++ b/tests/Providers/Auth/OctoberTest.php
@@ -32,7 +32,7 @@ class OctoberTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->october = Mockery::mock('October\Rain\Auth\Manager');
+        $this->october = Mockery::mock(\October\Rain\Auth\Manager::class);
         $this->auth = new Auth($this->october);
     }
 

--- a/tests/Providers/Auth/SentinelTest.php
+++ b/tests/Providers/Auth/SentinelTest.php
@@ -32,7 +32,7 @@ class SentinelTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->sentinel = Mockery::mock('Cartalyst\Sentinel\Sentinel');
+        $this->sentinel = Mockery::mock(\Cartalyst\Sentinel\Sentinel::class);
         $this->auth = new Auth($this->sentinel);
     }
 

--- a/tests/Providers/JWT/NamshiTest.php
+++ b/tests/Providers/JWT/NamshiTest.php
@@ -31,7 +31,7 @@ class NamshiTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->jws = Mockery::mock('Namshi\JOSE\JWS');
+        $this->jws = Mockery::mock(\Namshi\JOSE\JWS::class);
         $this->provider = new Namshi('secret', 'HS256', $this->jws);
     }
 

--- a/tests/Providers/Storage/IlluminateTest.php
+++ b/tests/Providers/Storage/IlluminateTest.php
@@ -41,7 +41,7 @@ class IlluminateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->cache = Mockery::mock('Illuminate\Contracts\Cache\Repository');
+        $this->cache = Mockery::mock(\Illuminate\Contracts\Cache\Repository::class);
         $this->storage = new Storage($this->cache);
     }
 


### PR DESCRIPTION
Use `::class` notation.

---

Also add missing `"illuminate/routing": "5.1.* || 5.2.*"` in `require-dev`