### PR TITLE
Let time related claims handle DateTimeInterface values with an abstract DatetimeClaim

### DIFF
--- a/src/Claims/DatetimeClaim.php
+++ b/src/Claims/DatetimeClaim.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tymon\JWTAuth\Claims;
 
 use DateTimeInterface;

--- a/src/Claims/DatetimeClaim.php
+++ b/src/Claims/DatetimeClaim.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tymon\JWTAuth\Claims;
+
+use DateTimeInterface;
+
+abstract class DatetimeClaim extends Claim
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setValue($value)
+    {
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->getTimestamp();
+        }
+
+        return parent::setValue($value);
+    }
+}

--- a/src/Claims/DatetimeClaim.php
+++ b/src/Claims/DatetimeClaim.php
@@ -26,4 +26,16 @@ abstract class DatetimeClaim extends Claim
 
         return parent::setValue($value);
     }
+
+    /**
+     * Validate the claim.
+     *
+     * @param  mixed  $value
+     *
+     * @return bool
+     */
+    public function validate($value)
+    {
+        return is_numeric($value);
+    }
 }

--- a/src/Claims/Expiration.php
+++ b/src/Claims/Expiration.php
@@ -11,7 +11,7 @@
 
 namespace Tymon\JWTAuth\Claims;
 
-class Expiration extends Claim
+class Expiration extends DatetimeClaim
 {
     /**
      * The claim name.

--- a/src/Claims/Expiration.php
+++ b/src/Claims/Expiration.php
@@ -29,6 +29,6 @@ class Expiration extends DatetimeClaim
      */
     public function validate($value)
     {
-        return is_numeric($value);
+        return parent::validate($value);
     }
 }

--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -11,7 +11,7 @@
 
 namespace Tymon\JWTAuth\Claims;
 
-class IssuedAt extends Claim
+class IssuedAt extends DatetimeClaim
 {
     /**
      * The claim name.

--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -29,6 +29,6 @@ class IssuedAt extends DatetimeClaim
      */
     public function validate($value)
     {
-        return is_numeric($value);
+        return parent::validate($value);
     }
 }

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -29,6 +29,6 @@ class NotBefore extends DatetimeClaim
      */
     public function validate($value)
     {
-        return is_numeric($value);
+        return parent::validate($value);
     }
 }

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -11,7 +11,7 @@
 
 namespace Tymon\JWTAuth\Claims;
 
-class NotBefore extends Claim
+class NotBefore extends DatetimeClaim
 {
     /**
      * The claim name.

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Test\Validators;
+
+use Mockery;
+use DateTime;
+use Carbon\Carbon;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Tymon\JWTAuth\Payload;
+use Tymon\JWTAuth\Claims\JwtId;
+use Tymon\JWTAuth\Claims\Issuer;
+use Tymon\JWTAuth\Claims\Subject;
+use Illuminate\Support\Collection;
+use Tymon\JWTAuth\Claims\IssuedAt;
+use Tymon\JWTAuth\Claims\NotBefore;
+use Tymon\JWTAuth\Claims\Expiration;
+use Tymon\JWTAuth\Test\AbstractTestCase;
+use Tymon\JWTAuth\Validators\PayloadValidator;
+
+class DatetimeClaimTest extends AbstractTestCase
+{
+    /**
+     * @var \Mockery\MockInterface
+     */
+    protected $validator;
+
+    /**
+     * @var \Carbon\Carbon
+     */
+    protected $testNowDatetime;
+
+    /**
+     * @var array
+     */
+    protected $claimsTimestamp;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->validator = Mockery::mock(PayloadValidator::class);
+        $this->validator->shouldReceive('setRefreshFlow->check');
+
+        $this->claimsTimestamp = [
+            'sub' => new Subject(1),
+            'iss' => new Issuer('http://example.com'),
+            'exp' => new Expiration($this->testNowTimestamp + 3600),
+            'nbf' => new NotBefore($this->testNowTimestamp),
+            'iat' => new IssuedAt($this->testNowTimestamp),
+            'jti' => new JwtId('foo'),
+        ];
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_should_handle_carbon_claims()
+    {
+        $testCarbon = Carbon::now();
+        $testCarbonCopy = clone $testCarbon;
+
+        $this->assertInstanceOf(Carbon::class, $testCarbon);
+        $this->assertInstanceOf(Datetime::class, $testCarbon);
+        $this->assertInstanceOf(DatetimeInterface::class, $testCarbon);
+
+        $claimsDatetime = [
+            'sub' => new Subject(1),
+            'iss' => new Issuer('http://example.com'),
+            'exp' => new Expiration($testCarbonCopy->addHour()),
+            'nbf' => new NotBefore($testCarbon),
+            'iat' => new IssuedAt($testCarbon),
+            'jti' => new JwtId('foo'),
+        ];
+
+        $payloadTimestamp = new Payload(Collection::make($this->claimsTimestamp), $this->validator);
+        $payloadDatetime = new Payload(Collection::make($claimsDatetime), $this->validator);
+
+        $this->assertEquals($payloadTimestamp, $payloadDatetime);
+    }
+
+    /** @test */
+    public function it_should_handle_datetime_claims()
+    {
+        $testDateTime = new DateTime();
+        $testDateTimeCopy = clone $testDateTime;
+
+        $this->assertInstanceOf(DateTime::class, $testDateTime);
+        $this->assertInstanceOf(DatetimeInterface::class, $testDateTime);
+
+        $claimsDatetime = [
+            'sub' => new Subject(1),
+            'iss' => new Issuer('http://example.com'),
+            'exp' => new Expiration($testDateTimeCopy->modify('+1 hour')),
+            'nbf' => new NotBefore($testDateTime),
+            'iat' => new IssuedAt($testDateTime),
+            'jti' => new JwtId('foo'),
+        ];
+
+        $payloadTimestamp = new Payload(Collection::make($this->claimsTimestamp), $this->validator);
+        $payloadDatetime = new Payload(Collection::make($claimsDatetime), $this->validator);
+
+        $this->assertEquals($payloadTimestamp, $payloadDatetime);
+    }
+
+    /** @test */
+    public function it_should_handle_datetime_immutable_claims()
+    {
+        $testDateTimeImmutable = new DateTimeImmutable();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $testDateTimeImmutable);
+        $this->assertInstanceOf(DatetimeInterface::class, $testDateTimeImmutable);
+
+        $claimsDatetime = [
+            'sub' => new Subject(1),
+            'iss' => new Issuer('http://example.com'),
+            'exp' => new Expiration($testDateTimeImmutable->modify('+1 hour')),
+            'nbf' => new NotBefore($testDateTimeImmutable),
+            'iat' => new IssuedAt($testDateTimeImmutable),
+            'jti' => new JwtId('foo'),
+        ];
+
+        $payloadTimestamp = new Payload(Collection::make($this->claimsTimestamp), $this->validator);
+        $payloadDatetime = new Payload(Collection::make($claimsDatetime), $this->validator);
+
+        $this->assertEquals($payloadTimestamp, $payloadDatetime);
+    }
+
+}

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -139,5 +139,4 @@ class DatetimeClaimTest extends AbstractTestCase
 
         $this->assertEquals($payloadTimestamp, $payloadDatetime);
     }
-
 }

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -35,11 +35,6 @@ class DatetimeClaimTest extends AbstractTestCase
     protected $validator;
 
     /**
-     * @var \Carbon\Carbon
-     */
-    protected $testNowDatetime;
-
-    /**
      * @var array
      */
     protected $claimsTimestamp;
@@ -71,7 +66,7 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test */
     public function it_should_handle_carbon_claims()
     {
-        $testCarbon = Carbon::now();
+        $testCarbon = Carbon::createFromTimestampUTC($this->testNowTimestamp);
         $testCarbonCopy = clone $testCarbon;
 
         $this->assertInstanceOf(Carbon::class, $testCarbon);
@@ -96,7 +91,7 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test */
     public function it_should_handle_datetime_claims()
     {
-        $testDateTime = new DateTime();
+        $testDateTime = DateTime::createFromFormat('U', $this->testNowTimestamp);
         $testDateTimeCopy = clone $testDateTime;
 
         $this->assertInstanceOf(DateTime::class, $testDateTime);
@@ -120,7 +115,7 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test */
     public function it_should_handle_datetime_immutable_claims()
     {
-        $testDateTimeImmutable = new DateTimeImmutable();
+        $testDateTimeImmutable = DateTimeImmutable::createFromFormat('U', $this->testNowTimestamp);
 
         $this->assertInstanceOf(DateTimeImmutable::class, $testDateTimeImmutable);
         $this->assertInstanceOf(DatetimeInterface::class, $testDateTimeImmutable);

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -100,7 +100,7 @@ class DatetimeClaimTest extends AbstractTestCase
         $claimsDatetime = [
             'sub' => new Subject(1),
             'iss' => new Issuer('http://example.com'),
-            'exp' => new Expiration($testDateTimeCopy->modify('+1 hour')),
+            'exp' => new Expiration($testDateTimeCopy->modify('+3600 seconds')),
             'nbf' => new NotBefore($testDateTime),
             'iat' => new IssuedAt($testDateTime),
             'jti' => new JwtId('foo'),
@@ -123,7 +123,7 @@ class DatetimeClaimTest extends AbstractTestCase
         $claimsDatetime = [
             'sub' => new Subject(1),
             'iss' => new Issuer('http://example.com'),
-            'exp' => new Expiration($testDateTimeImmutable->modify('+1 hour')),
+            'exp' => new Expiration($testDateTimeImmutable->modify('+3600 seconds')),
             'nbf' => new NotBefore($testDateTimeImmutable),
             'iat' => new IssuedAt($testDateTimeImmutable),
             'jti' => new JwtId('foo'),


### PR DESCRIPTION
Let time related claims handle DateTimeInterface values.

**Note:**
`return parent::validate($value);` is called because we keep the function description, and all all of them are slightly different.
If keeping them different is not so important, all `validate` functions can be removed from any class extending `\Tymon\JWTAuth\Claims\DatetimeClaim`

---

Solution for #510 