### PR TITLE
Remove class comment

### DIFF
--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -15,9 +15,6 @@ use Tymon\JWTAuth\Support\Utils;
 use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
-/**
- * Class PayloadValidator.
- */
 class PayloadValidator extends Validator
 {
     /**


### PR DESCRIPTION
Only one class comment was set in all files for `\Tymon\JWTAuth\Validators\PayloadValidator`.
I suppose this is not on purpose.