### PR TITLE
Fixes ResponseFactory not being instantiable building BaseMiddleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 build
+*.sublime*

--- a/src/Middleware/BaseMiddleware.php
+++ b/src/Middleware/BaseMiddleware.php
@@ -13,7 +13,6 @@ namespace Tymon\JWTAuth\Middleware;
 
 use Tymon\JWTAuth\JWTAuth;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Routing\ResponseFactory;
 
 abstract class BaseMiddleware
 {

--- a/src/Middleware/BaseMiddleware.php
+++ b/src/Middleware/BaseMiddleware.php
@@ -35,13 +35,12 @@ abstract class BaseMiddleware
     /**
      * Create a new BaseMiddleware instance.
      *
-     * @param \Illuminate\Contracts\Routing\ResponseFactory  $response
      * @param \Illuminate\Contracts\Events\Dispatcher  $events
      * @param \Tymon\JWTAuth\JWTAuth  $auth
      */
-    public function __construct(ResponseFactory $response, Dispatcher $events, JWTAuth $auth)
+    public function __construct(Dispatcher $events, JWTAuth $auth)
     {
-        $this->response = $response;
+        $this->response = response();
         $this->events = $events;
         $this->auth = $auth;
     }


### PR DESCRIPTION
Fixes [Target [Illuminate\Contracts\Routing\ResponseFactory] is not instantiable while building [...]](https://github.com/laravel/framework/issues/12368#issuecomment-185792630)