### PR TITLE
Fix issue where token has been passed within an array (for whatever reason) causes a generic exception

### DIFF
--- a/src/Validators/TokenValidator.php
+++ b/src/Validators/TokenValidator.php
@@ -36,6 +36,8 @@ class TokenValidator extends Validator
      */
     protected function validateStructure($token)
     {
+        $token = is_array($token) ? $token[array_keys($token)[0]] : $token;
+
         if (count(explode('.', $token)) !== 3) {
             throw new TokenInvalidException('Wrong number of segments');
         }


### PR DESCRIPTION
On rare occasions the token may be passed to the validator in an array, resulting in an Exception thanks to the explode function. Token will be type checked first to extract it from the array if such a case happens.

Case of this happening: A notification drop down <a> contains a href to a laravel route but we want to display the number of notifications available using AJAX to periodically update the value; Javascript disables the default href action and implements an AJAX listener to send a "clear notifications" request whenever the notification <a> is clicked. Initiating that AJAX request and then clicking another link while the request is still happening caused the JWToken to be passed in an array rather than a string.