### PR TITLE
Directly call \DateTime::getTimestamp

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -158,7 +158,7 @@ class Blacklist
      */
     protected function getGraceTimestamp()
     {
-        return Utils::now()->addSeconds($this->gracePeriod)->timestamp;
+        return Utils::now()->addSeconds($this->gracePeriod)->getTimestamp();
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -163,7 +163,7 @@ class Factory
      */
     public function iat()
     {
-        return Utils::now()->timestamp;
+        return Utils::now()->getTimestamp();
     }
 
     /**
@@ -173,7 +173,7 @@ class Factory
      */
     public function exp()
     {
-        return Utils::now()->addMinutes($this->ttl)->timestamp;
+        return Utils::now()->addMinutes($this->ttl)->getTimestamp();
     }
 
     /**
@@ -183,7 +183,7 @@ class Factory
      */
     public function nbf()
     {
-        return Utils::now()->timestamp;
+        return Utils::now()->getTimestamp();
     }
 
     /**

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -28,7 +28,7 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
         $now = Carbon::now();
 
         Carbon::setTestNow($now);
-        $this->testNowTimestamp = $now->timestamp;
+        $this->testNowTimestamp = $now->getTimestamp();
     }
 
     public function tearDown()


### PR DESCRIPTION
Directly call `\DateTime::getTimestamp`, no need to call `\Carbon\Carbon::__get`