### PR TITLE
Update php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^5.5.9 || ^7.0",
         "illuminate/auth": "5.1.* || 5.2.*",
         "illuminate/contracts": "5.1.* || 5.2.*",
         "illuminate/http": "5.1.* || 5.2.*",


### PR DESCRIPTION
Instead of allowing all future versions of PHP we can be more specific.