### PR TITLE
Move \Middleware to \Http\Middleware

### DIFF
--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Middleware;
+namespace Tymon\JWTAuth\Http\Middleware;
 
 use Closure;
 use Tymon\JWTAuth\Exceptions\JWTException;

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Middleware;
+namespace Tymon\JWTAuth\Http\Middleware;
 
 use Tymon\JWTAuth\JWTAuth;
 use Illuminate\Http\Request;

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Middleware;
+namespace Tymon\JWTAuth\Http\Middleware;
 
 use Closure;
 use Exception;

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Middleware;
+namespace Tymon\JWTAuth\Http\Middleware;
 
 use Closure;
 use Tymon\JWTAuth\Exceptions\JWTException;

--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -11,9 +11,9 @@
 
 namespace Tymon\JWTAuth\Providers;
 
-use Tymon\JWTAuth\Middleware\Check;
-use Tymon\JWTAuth\Middleware\Authenticate;
-use Tymon\JWTAuth\Middleware\RefreshToken;
+use Tymon\JWTAuth\Http\Middleware\Check;
+use Tymon\JWTAuth\Http\Middleware\Authenticate;
+use Tymon\JWTAuth\Http\Middleware\RefreshToken;
 
 class LaravelServiceProvider extends AbstractServiceProvider
 {

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -17,7 +17,7 @@ use Illuminate\Http\Request;
 use Tymon\JWTAuth\Http\Parser;
 use Tymon\JWTAuth\Test\Stubs\UserStub;
 use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Middleware\Authenticate;
+use Tymon\JWTAuth\Http\Middleware\Authenticate;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
 class AuthenticateTest extends AbstractTestCase
@@ -33,7 +33,7 @@ class AuthenticateTest extends AbstractTestCase
     protected $request;
 
     /**
-     * @var \Tymon\JWTAuth\Middleware\Authenticate
+     * @var \Tymon\JWTAuth\Http\Middleware\Authenticate
      */
     protected $middleware;
 

--- a/tests/Middleware/CheckTest.php
+++ b/tests/Middleware/CheckTest.php
@@ -15,8 +15,8 @@ use Mockery;
 use Tymon\JWTAuth\JWTAuth;
 use Illuminate\Http\Request;
 use Tymon\JWTAuth\Http\Parser;
-use Tymon\JWTAuth\Middleware\Check;
 use Tymon\JWTAuth\Test\Stubs\UserStub;
+use Tymon\JWTAuth\Http\Middleware\Check;
 use Tymon\JWTAuth\Test\AbstractTestCase;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
@@ -33,7 +33,7 @@ class CheckTest extends AbstractTestCase
     protected $request;
 
     /**
-     * @var \Tymon\JWTAuth\Middleware\Check
+     * @var \Tymon\JWTAuth\Http\Middleware\Check
      */
     protected $middleware;
 

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -17,7 +17,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Tymon\JWTAuth\Http\Parser;
 use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Middleware\RefreshToken;
+use Tymon\JWTAuth\Http\Middleware\RefreshToken;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
 class RefreshTokenTest extends AbstractTestCase
@@ -33,7 +33,7 @@ class RefreshTokenTest extends AbstractTestCase
     protected $request;
 
     /**
-     * @var \Tymon\JWTAuth\Middleware\RefreshToken
+     * @var \Tymon\JWTAuth\Http\Middleware\RefreshToken
      */
     protected $middleware;
 


### PR DESCRIPTION
Respect Laravel app architecture and move \Middleware to \Http\Middleware