### PR TITLE
Fix , => typo in LumenServiceProvider

### DIFF
--- a/src/Providers/LumenServiceProvider.php
+++ b/src/Providers/LumenServiceProvider.php
@@ -32,7 +32,7 @@ class LumenServiceProvider extends AbstractServiceProvider
         $this->mergeConfigFrom($path, 'jwt');
 
         $this->app->routeMiddleware([
-            'jwt.auth', Authenticate::class,
+            'jwt.auth' => Authenticate::class,
             'jwt.refresh' => RefreshToken::class,
             'jwt.renew' => AuthenticateAndRenew::class,
             'jwt.check' => Check::class,


### PR DESCRIPTION
Otherwise this seems to yield

![screen shot 2016-03-18 at 10 01 33 am](https://cloud.githubusercontent.com/assets/3766240/13881930/10bcee60-ecf1-11e5-8889-7a2977cd32ee.png)
