### PR TITLE
Add Ability To Set Infinite Refresh TTL

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -112,6 +112,11 @@ return [
     | the original token being created until they must re-authenticate.
     | Defaults to 2 weeks.
     |
+    | You can also set this to null, to yield an infinite refresh time.
+    | Some may want this instead of never expiring tokens for e.g. a mobile app.
+    | This is not particularly recommended, so make sure you have appropriate
+    | systems in place to revoke the token if necessary.
+    |
     */
 
     'refresh_ttl' => env('JWT_REFRESH_TTL', 20160),

--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -102,6 +102,10 @@ class PayloadValidator extends Validator
      */
     protected function validateRefresh(array $payload)
     {
+        if ($this->refreshTTL === null) {
+            return true;
+        }
+
         if (isset($payload['iat']) && Utils::isPast($payload['iat'] + $this->refreshTTL * 60)) {
             throw new TokenExpiredException('Token has expired and can no longer be refreshed');
         }

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -156,6 +156,23 @@ class PayloadValidatorTest extends AbstractTestCase
         );
     }
 
+    /** @test */
+    public function it_should_return_true_if_the_refresh_ttl_is_null()
+    {
+        $payload = [
+            'iss' => 'http://example.com',
+            'iat' => $this->testNowTimestamp - 2600,
+            'nbf' => $this->testNowTimestamp,
+            'exp' => $this->testNowTimestamp - 1000,
+            'sub' => 1,
+            'jti' => 'foo',
+        ];
+
+        $this->assertTrue(
+            $this->validator->setRefreshFlow()->setRefreshTTL(null)->isValid($payload)
+        );
+    }
+
     /**
      * @test
      * @expectedException \Tymon\JWTAuth\Exceptions\TokenExpiredException


### PR DESCRIPTION
Similar to how never expiring tokens is currently supported, adds support for infinite refresh TTL time. 

Just like how you can set `JWT_TTL=null`, adds support to set `JWT_REFRESH_TTL=null`.

Opposed to using never expiring tokens, a mobile app developer may want the additional security of having tokens expire after some time (say, in case it is compromised in transit somehow, at least it may expire before it could be used maliciously), but allows the mobile app to refresh the token with the server at any time after it expires.