### PR TITLE
added JSON_NUMERIC_CHECK to json_encode

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -146,7 +146,7 @@ class Payload implements ArrayAccess, Arrayable, JsonSerializable, Jsonable, Cou
      */
     public function __toString()
     {
-        return $this->toJson(JSON_UNESCAPED_SLASHES);
+        return $this->toJson(JSON_NUMERIC_CHECK & JSON_UNESCAPED_SLASHES);
     }
 
     /**


### PR DESCRIPTION
Based on the JWT specs, the expiration date should be returned as a number. I've created an issue #654 describing an issue I had trying to use the token generated within a iOS app where it would reject the exp since it wasn't a number.

The proposed fix should fix the issue.