### PR TITLE
Tests \Tymon\JWTAuth\Support\CustomClaims::customClaims

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -73,7 +73,7 @@ class FactoryTest extends AbstractTestCase
         $this->claimFactory->shouldReceive('get')->once()->with('nbf', 123)->andReturn(new NotBefore(123));
         $this->claimFactory->shouldReceive('get')->once()->with('exp', $expTime)->andReturn(new Expiration($expTime));
 
-        $payload = $this->factory->claims(['sub' => 1, 'jti' => 'foo', 'iat' => 123, 'nbf' => 123])->make();
+        $payload = $this->factory->customClaims(['sub' => 1, 'jti' => 'foo', 'iat' => 123, 'nbf' => 123])->make();
 
         $this->assertSame($payload->get('sub'), 1);
         $this->assertSame($payload->get('iat'), 123);


### PR DESCRIPTION
Test `\Tymon\JWTAuth\Support\CustomClaims::customClaims`, not its alias.

---

Tests failing for another reason