### PR TITLE
Add return void docblock

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -44,6 +44,8 @@ class Blacklist
 
     /**
      * @param  \Tymon\JWTAuth\Contracts\Providers\Storage  $storage
+     *
+     * @return void
      */
     public function __construct(Storage $storage)
     {

--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -34,6 +34,7 @@ abstract class Claim implements ClaimContract, Jsonable, JsonSerializable
 
     /**
      * @param  mixed  $value
+     * @return void
      */
     public function __construct($value)
     {

--- a/src/Claims/Custom.php
+++ b/src/Claims/Custom.php
@@ -16,6 +16,7 @@ class Custom extends Claim
     /**
      * @param  string  $name
      * @param  mixed  $value
+     * @return void
      */
     public function __construct($name, $value)
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -58,6 +58,7 @@ class Factory
      * @param  \Tymon\JWTAuth\Claims\Factory  $claimFactory
      * @param  \Illuminate\Http\Request  $request
      * @param  \Tymon\JWTAuth\Validators\PayloadValidator  $validator
+     * @return void
      */
     public function __construct(ClaimFactory $claimFactory, Request $request, PayloadValidator $validator)
     {

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -28,6 +28,7 @@ abstract class BaseMiddleware
      * Create a new BaseMiddleware instance.
      *
      * @param  \Tymon\JWTAuth\JWTAuth  $auth
+     * @return void
      */
     public function __construct(JWTAuth $auth)
     {

--- a/src/Http/Parser/Parser.php
+++ b/src/Http/Parser/Parser.php
@@ -28,6 +28,7 @@ class Parser
     /**
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $chain
+     * @return void
      */
     public function __construct(Request $request, array $chain = [])
     {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -40,6 +40,7 @@ class JWT
     /**
      * @param  \Tymon\JWTAuth\Manager  $manager
      * @param  \Tymon\JWTAuth\Http\Parser\Parser  $parser
+     * @return void
      */
     public function __construct(Manager $manager, Parser $parser)
     {

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -25,6 +25,7 @@ class JWTAuth extends JWT
      * @param  \Tymon\JWTAuth\Manager  $manager
      * @param  \Tymon\JWTAuth\Contracts\Providers\Auth  $auth
      * @param  \Tymon\JWTAuth\Http\Parser\Parser  $parser
+     * @return void
      */
     public function __construct(Manager $manager, Auth $auth, Parser $parser)
     {

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -50,6 +50,7 @@ class JWTGuard implements Guard
      * @param  \Tymon\JWTAuth\JWT  $jwt
      * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
      * @param  \Illuminate\Http\Request  $request
+     * @return void
      */
     public function __construct(JWT $jwt, UserProvider $provider, Request $request)
     {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -45,6 +45,7 @@ class Manager
      * @param  \Tymon\JWTAuth\Contracts\Providers\JWT  $provider
      * @param  \Tymon\JWTAuth\Blacklist  $blacklist
      * @param  \Tymon\JWTAuth\Factory  $payloadFactory
+     * @return void
      */
     public function __construct(JWTContract $provider, Blacklist $blacklist, Factory $payloadFactory)
     {

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -39,6 +39,7 @@ class Payload implements ArrayAccess, Arrayable, JsonSerializable, Jsonable, Cou
      * @param  \Illuminate\Support\Collection  $claims
      * @param  \Tymon\JWTAuth\Validators\PayloadValidator  $validator
      * @param  bool  $refreshFlow
+     * @return void
      */
     public function __construct(Collection $claims, PayloadValidator $validator, $refreshFlow = false)
     {

--- a/src/Providers/Auth/Illuminate.php
+++ b/src/Providers/Auth/Illuminate.php
@@ -23,6 +23,7 @@ class Illuminate implements Auth
 
     /**
      * @param  \Illuminate\Contracts\Auth\Guard  $auth
+     * @return void
      */
     public function __construct(GuardContract $auth)
     {

--- a/src/Providers/Auth/October.php
+++ b/src/Providers/Auth/October.php
@@ -23,6 +23,7 @@ class October implements Auth
 
     /**
      * @param  \October\Rain\Auth\Manager  $october
+     * @return void
      */
     public function __construct(OctoberAuth $october)
     {

--- a/src/Providers/Auth/Sentinel.php
+++ b/src/Providers/Auth/Sentinel.php
@@ -23,6 +23,7 @@ class Sentinel implements Auth
 
     /**
      * @param  \Cartalyst\Sentinel\Sentinel  $sentinel
+     * @return void
      */
     public function __construct(SentinelAuth $sentinel)
     {

--- a/src/Providers/JWT/Namshi.php
+++ b/src/Providers/JWT/Namshi.php
@@ -32,6 +32,7 @@ class Namshi extends Provider implements JWT
      * @param  string  $algo
      * @param  array  $keys
      * @param  string|null  $driver
+     * @return void
      */
     public function __construct($secret, $algo, array $keys = [], $driver = null)
     {

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -34,6 +34,7 @@ abstract class Provider
      * @param  string  $secret
      * @param  array  $keys
      * @param  string  $algo
+     * @return void
      */
     public function __construct($secret, array $keys, $algo)
     {

--- a/src/Providers/Storage/Illuminate.php
+++ b/src/Providers/Storage/Illuminate.php
@@ -34,6 +34,7 @@ class Illuminate implements Storage
 
     /**
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @return void
      */
     public function __construct(CacheContract $cache)
     {

--- a/src/Token.php
+++ b/src/Token.php
@@ -24,6 +24,7 @@ class Token
      * Create a new JSON Web Token.
      *
      * @param  string  $value
+     * @return void
      */
     public function __construct($value)
     {


### PR DESCRIPTION
Return void was sometimes set for `__construct`, sometimes not.
This PR sets it everywhere to respect Laravel coding style

---

**Note:** in some cases there is an empty line before `@return`, in some other not.
StyleCI does not find anything wrong - but IMO, it think it should 