### PR TITLE
Update branch-alias to 1.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "0.6-dev"
+            "dev-develop": "1.0-dev"
         }
     },
     "prefer-stable": true,


### PR DESCRIPTION
You're building the 1.0 version on the develop branch now, right? Or are you still planning to release 0.6?
In that case, change the branch-alias to 1.0, so people can require `1.x@dev` and get the latest dev version (instead of the alpha)