### PR TITLE
Skip token validation when user is already set

### DIFF
--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -27,7 +27,9 @@ class Authenticate extends BaseMiddleware
      */
     public function handle($request, Closure $next)
     {
-        $this->authenticate($request);
+        if (! $this->auth->userExists()) {
+            $this->authenticate($request);
+        }
 
         return $next($request);
     }

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -27,11 +27,11 @@ class AuthenticateAndRenew extends BaseMiddleware
      */
     public function handle($request, Closure $next)
     {
-        if (! $this->auth->userExists()) {
-            $this->authenticate($request);
-        } elseif (! $this->auth->check()) {
+        if ($this->auth->userExists() && ! $this->auth->check()) {
             return $next($request);
         }
+
+        $this->authenticate($request);
 
         $response = $next($request);
 

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -27,7 +27,11 @@ class AuthenticateAndRenew extends BaseMiddleware
      */
     public function handle($request, Closure $next)
     {
-        $this->authenticate($request);
+        if (! $this->auth->userExists()) {
+            $this->authenticate($request);
+        } elseif (! $this->auth->check()) {
+            return $next($request);
+        }
 
         $response = $next($request);
 

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -33,6 +33,12 @@ class RefreshToken extends BaseMiddleware
             return $next($request);
         }
 
+        $response = $next($request);
+
+        if (! is_null($response->exception)) {
+            return $response;
+        }
+
         $this->checkForToken($request);
 
         try {
@@ -40,8 +46,6 @@ class RefreshToken extends BaseMiddleware
         } catch (JWTException $e) {
             throw new UnauthorizedHttpException('jwt-auth', $e->getMessage(), $e, $e->getCode());
         }
-
-        $response = $next($request);
 
         // send the refreshed token back to the client
         $response->headers->set('Authorization', 'Bearer '.$token);

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -29,6 +29,10 @@ class RefreshToken extends BaseMiddleware
      */
     public function handle($request, Closure $next)
     {
+        if ($this->auth->userExists() && ! $this->auth->check()) {
+            return $next($request);
+        }
+
         $this->checkForToken($request);
 
         try {

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -35,7 +35,7 @@ class RefreshToken extends BaseMiddleware
 
         $response = $next($request);
 
-        if (! is_null($response->exception)) {
+        if (isset($response->exception) && ! is_null($response->exception)) {
             return $response;
         }
 

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -85,4 +85,14 @@ class JWTAuth extends JWT
     {
         return $this->auth->user();
     }
+
+    /**
+     * Determine if the user is authenticated.
+     *
+     * @return bool
+     */
+    public function userExists()
+    {
+        return ! is_null($this->user());
+    }
 }

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -60,8 +60,11 @@ class AuthenticateAndRenewTest extends AbstractTestCase
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
+
         $this->auth->shouldReceive('parser')->andReturn($parser);
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub);
 
@@ -70,6 +73,16 @@ class AuthenticateAndRenewTest extends AbstractTestCase
         $response = $this->middleware->handle($this->request, function () { return new Response; });
 
         $this->assertSame($response->headers->get('authorization'), 'Bearer foo.bar.baz');
+    }
+
+    /** @test */
+    public function it_should_authenticate_a_user_without_token_if_user_is_already_set()
+    {
+        $this->auth->shouldReceive('userExists')->once()->andReturn(true);
+
+        $this->auth->shouldReceive('check')->once()->andReturn(false);
+
+        $this->middleware->handle($this->request, function () {});
     }
 
     /**
@@ -83,6 +96,8 @@ class AuthenticateAndRenewTest extends AbstractTestCase
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
 
         $this->middleware->handle($this->request, function () {});
     }
@@ -99,6 +114,9 @@ class AuthenticateAndRenewTest extends AbstractTestCase
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
+
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException);
 
         $this->middleware->handle($this->request, function () {});

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -63,7 +63,18 @@ class AuthenticateTest extends AbstractTestCase
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
+
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub);
+
+        $this->middleware->handle($this->request, function () {});
+    }
+
+    /** @test */
+    public function it_should_authenticate_a_user_without_token_if_user_is_already_set()
+    {
+        $this->auth->shouldReceive('userExists')->once()->andReturn(true);
 
         $this->middleware->handle($this->request, function () {});
     }
@@ -80,6 +91,8 @@ class AuthenticateTest extends AbstractTestCase
         $this->auth->shouldReceive('parser')->andReturn($parser);
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
 
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
+
         $this->middleware->handle($this->request, function () {});
     }
 
@@ -95,6 +108,8 @@ class AuthenticateTest extends AbstractTestCase
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
+
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException);
 
         $this->middleware->handle($this->request, function () {});

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -63,11 +63,24 @@ class RefreshTokenTest extends AbstractTestCase
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
+
         $this->auth->shouldReceive('parseToken->refresh')->once()->andReturn('foo.bar.baz');
 
         $response = $this->middleware->handle($this->request, function () { return new Response; });
 
         $this->assertSame($response->headers->get('authorization'), 'Bearer foo.bar.baz');
+    }
+
+    /** @test */
+    public function it_should_not_refresh_a_token_if_user_is_already_set()
+    {
+        $this->auth->shouldReceive('userExists')->once()->andReturn(true);
+
+        $this->auth->shouldReceive('check')->once()->andReturn(false);
+
+        $this->middleware->handle($this->request, function () {});
     }
 
     /**
@@ -81,6 +94,8 @@ class RefreshTokenTest extends AbstractTestCase
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
 
         $this->middleware->handle($this->request, function () {});
     }
@@ -97,6 +112,9 @@ class RefreshTokenTest extends AbstractTestCase
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+
+        $this->auth->shouldReceive('userExists')->once()->andReturn(false);
+
         $this->auth->shouldReceive('parseToken->refresh')->once()->andThrow(new TokenInvalidException);
 
         $this->middleware->handle($this->request, function () {});


### PR DESCRIPTION
There is a situations where we need to set user manually and internally dispatch routes that uses jwt auth without token validation
