### PR TITLE
Add `check()` method to the guard

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -229,6 +229,16 @@ class JWTGuard implements Guard
     {
         return $this->getPayload();
     }
+    
+    /**
+     * Check the token is valid
+     * 
+     * @return bool
+     */
+    public function check()
+    {
+        return $this->jwt->check();
+    }
 
     /**
      * Set the token.


### PR DESCRIPTION
without this method we always get `true` when calling `Auth::setToken($token)->check()`