### PR TITLE
Do not try to refresh a token if no token is set in request

### DIFF
--- a/src/Middleware/RefreshToken.php
+++ b/src/Middleware/RefreshToken.php
@@ -27,6 +27,11 @@ class RefreshToken extends BaseMiddleware
     {
         $response = $next($request);
 
+        //do not try to refresh a token if no token is set in request
+        if (!$this->auth->setRequest($request)->getToken()) {
+          return $response;
+        }
+
         try {
             $newToken = $this->auth->setRequest($request)->parseToken()->refresh();
         } catch (TokenExpiredException $e) {


### PR DESCRIPTION
I use Dingo for building an API with multiple authentication methods allowed at the same time (basic and JWT). If the user uses JWT to authenticate, then a token is present and can be refreshed by using the jwt.refresh middleware.

But if the user uses basic auth, then no token is present that can be refreshed thus leading to an exception. So in my opinion the refresh middleware should try to refresh the token only if a token is present and if no token is present the middleware should return the plain response.

This behaviour would solve some trouble for me so I would be happy if the request gets accepted.