### PR TITLE
Fix claims array comparisons

### DIFF
--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -115,7 +115,7 @@ class PayloadFactory
     protected function buildClaims(array $customClaims)
     {
         // add any custom claims first
-        $this->addClaims(array_diff_key($customClaims, $this->defaultClaims));
+        $this->addClaims($customClaims);
 
         foreach ($this->defaultClaims as $claim) {
             if (! array_key_exists($claim, $customClaims)) {

--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -54,7 +54,7 @@ class PayloadValidator extends AbstractValidator
      */
     protected function validateStructure(array $payload)
     {
-        if (count(array_diff_key($this->requiredClaims, array_keys($payload))) !== 0) {
+        if (count(array_diff($this->requiredClaims, array_keys($payload))) !== 0) {
             throw new TokenInvalidException('JWT payload does not contain the required claims');
         }
 

--- a/tests/PayloadFactoryTest.php
+++ b/tests/PayloadFactoryTest.php
@@ -61,6 +61,26 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Tymon\JWTAuth\Payload', $payload);
     }
+    
+    /** @test **/
+    public function it_should_check_custom_claim_keys_accurately_and_accept_numeric_claims()
+    {
+        $this->validator->shouldReceive('setRefreshFlow->check');
+        
+        $this->claimFactory->shouldReceive('get')->once()->with('iss', Mockery::any())->andReturn(new Issuer('/foo'));
+        $this->claimFactory->shouldReceive('get')->once()->with('exp', 123 + 3600)->andReturn(new Expiration(123 + 3600));
+        $this->claimFactory->shouldReceive('get')->once()->with('iat', 123)->andReturn(new IssuedAt(123));
+        $this->claimFactory->shouldReceive('get')->once()->with('jti', Mockery::any())->andReturn(new JwtId('foo'));
+        $this->claimFactory->shouldReceive('get')->once()->with('nbf', 123)->andReturn(new NotBefore(123));
+        $this->claimFactory->shouldReceive('get')->once()->with(1, 'claim one')->andReturn(new Custom(1, 'claim one'));
+        
+        $payload = $this->factory->make([1 => 'claim one']);
+        
+        // if the checker doesn't compare defaults properly, numeric-keyed claims might be ignored 
+        $this->assertEquals('claim one', $payload->get(1));
+        // iat is $defaultClaims[1], so verify it wasn't skipped due to a bad k-v comparison
+        $this->assertEquals(123, $payload->get('iat'));
+    }
 
     /** @test */
     public function it_should_return_a_payload_when_chaining_claim_methods()

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -116,4 +116,27 @@ class PayloadValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->check($payload);
     }
+    
+    /** @test **/
+    public function it_should_throw_an_exception_when_required_claims_are_missing()
+    {
+        $this->setExpectedException('Tymon\JWTAuth\Exceptions\TokenInvalidException');
+        
+        $payload = [
+            'iss' => 'http://example.com',
+            'foo' => 'bar',
+            // these are inserted to check for regression to a previous bug
+            // where the check would only compare keys of autoindexed name arrays
+            // (There are enough to account for all of the required claims' indices)
+            'autoindexed', 
+            'autoindexed',
+            'autoindexed',
+            'autoindexed',
+            'autoindexed',
+            'autoindexed',
+            'autoindexed',
+        ];
+        
+        $this->validator->check($payload);
+    }
 }


### PR DESCRIPTION
Issue in 0.5 that I mentioned in #719.

- Simplify `PayloadFactory` addition of custom claims and prevent issue with numerically-keyed claims.
- Fix `PayloadValidator` required claims check, which was only verifying that there were at least as many claims as requireds and not comparing keys.
- Create tests for both scenarios.