### PR TITLE
Bailout to json_encode when building jti claims

### DIFF
--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -191,6 +191,10 @@ class PayloadFactory
         $sub = array_get($this->claims, 'sub', '');
         $nbf = array_get($this->claims, 'nbf', '');
 
+        if (!is_string($sub)) {
+            $sub = json_encode($sub);
+        }
+
         return md5(sprintf('jti.%s.%s', $sub, $nbf));
     }
 

--- a/tests/PayloadFactoryTest.php
+++ b/tests/PayloadFactoryTest.php
@@ -85,11 +85,12 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_should_return_a_payload_when_passing_miltidimensional_array_as_custom_claim_to_make_method()
+    public function it_should_return_a_payload_when_passing_miltidimensional_claims()
     {
         $this->validator->shouldReceive('setRefreshFlow->check');
+        $userObject = ['name' => 'example'];
 
-        $this->claimFactory->shouldReceive('get')->once()->with('sub', 1)->andReturn(new Subject(1));
+        $this->claimFactory->shouldReceive('get')->once()->with('sub', $userObject)->andReturn(new Subject($userObject));
         $this->claimFactory->shouldReceive('get')->once()->with('iss', Mockery::any())->andReturn(new Issuer('/foo'));
         $this->claimFactory->shouldReceive('get')->once()->with('exp', Mockery::any())->andReturn(new Expiration(123 + 3600));
         $this->claimFactory->shouldReceive('get')->once()->with('iat', Mockery::any())->andReturn(new IssuedAt(123));
@@ -97,9 +98,9 @@ class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
         $this->claimFactory->shouldReceive('get')->once()->with('nbf', Mockery::any())->andReturn(new NotBefore(123));
         $this->claimFactory->shouldReceive('get')->once()->with('foo', ['bar' => [0, 0, 0]])->andReturn(new Custom('foo', ['bar' => [0, 0, 0]]));
 
-        $payload = $this->factory->sub(1)->foo(['bar' => [0, 0, 0]])->make();
+        $payload = $this->factory->sub($userObject)->foo(['bar' => [0, 0, 0]])->make();
 
-        $this->assertEquals($payload->get('sub'), 1);
+        $this->assertEquals($payload->get('sub'), $userObject);
         $this->assertEquals($payload->get('foo'), ['bar' => [0, 0, 0]]);
 
         $this->assertInstanceOf('Tymon\JWTAuth\Payload', $payload);


### PR DESCRIPTION
The default `jti` would stumble on unstringable `sub` values, which were occasionally happening for some users.

Addresses #719 and #351 and another one I can't find. Or rather it fixes a _symptom_ of those issues. I don't think anyone has identified why they had a non-standard subject value (and whether it was their app or some edge case in the library), but there isn't a good reason `jti` should choke on that scenario.