### PR TITLE
Added an exception to JWTGuard->user()

### DIFF
--- a/src/Exceptions/UserNotDefinedException.php
+++ b/src/Exceptions/UserNotDefinedException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Exceptions;
+
+class UserNotDefinedException extends JWTException
+{
+    //
+}

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -76,7 +76,7 @@ class JWTGuard implements Guard
 
             return $this->user = $this->provider->retrieveById($id);
         }
-        
+
         throw new JWTException();
     }
 

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -76,6 +76,8 @@ class JWTGuard implements Guard
 
             return $this->user = $this->provider->retrieveById($id);
         }
+        
+        throw new JWTException();
     }
 
     /**

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -17,6 +17,7 @@ use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
 use Tymon\JWTAuth\Contracts\JWTSubject;
 use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
 use Illuminate\Contracts\Auth\UserProvider;
 
 class JWTGuard implements Guard

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -15,6 +15,7 @@ use BadMethodCallException;
 use Illuminate\Http\Request;
 use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
+use October\Rain\Auth\Models\User;
 use Tymon\JWTAuth\Contracts\JWTSubject;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
@@ -65,6 +66,7 @@ class JWTGuard implements Guard
      * Get the currently authenticated user.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @throws UserNotDefinedException
      */
     public function user()
     {
@@ -78,7 +80,7 @@ class JWTGuard implements Guard
             return $this->user = $this->provider->retrieveById($id);
         }
 
-        throw new JWTException();
+        throw new UserNotDefinedException();
     }
 
     /**

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -109,7 +109,7 @@ class JWTGuardTest extends AbstractTestCase
      * @test
      * @group laravel-5.2
      */
-    public function it_should_return_null_if_no_token_is_provided()
+    public function it_should_throw_an_exception_if_no_token_is_provided()
     {
         $this->expectException(UserNotDefinedException::class);
 

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -12,6 +12,7 @@
 namespace Tymon\JWTAuth\Test;
 
 use Mockery;
+use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
 use Tymon\JWTAuth\JWT;
 use Tymon\JWTAuth\Factory;
 use Tymon\JWTAuth\Payload;
@@ -91,15 +92,17 @@ class JWTGuardTest extends AbstractTestCase
      * @test
      * @group laravel-5.2
      */
-    public function it_should_return_null_if_an_invalid_token_is_provided()
+    public function it_should_throw_an_exception_if_an_invalid_token_is_provided()
     {
+        $this->expectException(UserNotDefinedException::class);
+
         $this->jwt->shouldReceive('getToken')->twice()->andReturn('invalid.token.here');
         $this->jwt->shouldReceive('check')->twice()->andReturn(false);
         $this->jwt->shouldReceive('getPayload->get')->never();
         $this->provider->shouldReceive('retrieveById')->never();
 
-        $this->assertNull($this->guard->user()); // once
-        $this->assertFalse($this->guard->check()); // twice
+        $this->assertFalse($this->guard->check()); // once
+        $this->guard->user(); // twice, throws the exception
     }
 
     /**
@@ -108,13 +111,15 @@ class JWTGuardTest extends AbstractTestCase
      */
     public function it_should_return_null_if_no_token_is_provided()
     {
+        $this->expectException(UserNotDefinedException::class);
+
         $this->jwt->shouldReceive('getToken')->andReturn(false);
         $this->jwt->shouldReceive('check')->never();
         $this->jwt->shouldReceive('getPayload->get')->never();
         $this->provider->shouldReceive('retrieveById')->never();
 
-        $this->assertNull($this->guard->user());
         $this->assertFalse($this->guard->check());
+        $this->guard->user(); // throws the exception
     }
 
     /**


### PR DESCRIPTION
Made `JWTGuard->user()` throw an exception instead of simply returning nothing. If it returns null, it's too annoying to check everywhere. An exception thrown would avoid that.