### PR TITLE
Made the JWTGuard->user() method throw an exception in case of failure

### DIFF
--- a/src/Exceptions/UserNotDefinedException.php
+++ b/src/Exceptions/UserNotDefinedException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Exceptions;
+
+class UserNotDefinedException extends JWTException
+{
+    //
+}

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -17,6 +17,7 @@ use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
 use Tymon\JWTAuth\Contracts\JWTSubject;
 use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
 use Illuminate\Contracts\Auth\UserProvider;
 
 class JWTGuard implements Guard
@@ -76,6 +77,22 @@ class JWTGuard implements Guard
 
             return $this->user = $this->provider->retrieveById($id);
         }
+    }
+
+    /**
+     * Get the currently authenticated user or throws an exception.
+     *
+     * @throws UserNotDefinedException
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function userOrFail()
+    {
+        if (! $user = $this->user()) {
+            throw new UserNotDefinedException;
+        }
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Before the method used to return `null` which was a cause of frustration every time someone wanted to just do `Auth::user()->email` (for example). Instead, we had to perform checks every time we call that function. With the exception thrown instead, we can ensure that nothing unexpected happens and keep the code clean.

Note: I wasn't sure how to name the exception the best way, so change it to whatever you think is better.