### PR TITLE
Give secret generation command a `--force` option

### DIFF
--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -21,7 +21,7 @@ class JWTGenerateSecretCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'jwt:secret {--s|show : Display the key instead of modifying files.}';
+    protected $signature = 'jwt:secret {--s|show : Display the key instead of modifying files.} {--f|force : Skip confirmation when overwriting an existing key.}';
 
     /**
      * The console command description.
@@ -52,8 +52,8 @@ class JWTGenerateSecretCommand extends Command
                 file_put_contents($path, PHP_EOL."JWT_SECRET=$key", FILE_APPEND);
             } else {
 
-                // let's be sure you want to do this
-                $confirmed = $this->confirm('This will invalidate all existing tokens. Are you sure you want to override the secret key?');
+                // let's be sure you want to do this, unless you already told us to force it
+                $confirmed = $this->option('force') || $this->confirm('This will invalidate all existing tokens. Are you sure you want to override the secret key?');
 
                 if ($confirmed) {
                     file_put_contents($path, str_replace(


### PR DESCRIPTION
As it stands you cannot generally call `JWTGenerateSecretCommand` from code because it will hit a user confirmation dialog when replacing an existing key, and as far as I can tell, there isn't an easy way to respond to artisan command dialogs from within the application. Providing a `--force` option allows us to skip this dialog for in-app command calls (it can also simplify build scripts that might be regenerating keys, so they no longer need to pipe in a "y").