### PR TITLE
added a Doctrine auth adapter

### DIFF
--- a/src/Providers/Auth/Doctrine.php
+++ b/src/Providers/Auth/Doctrine.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+* This file is part of jwt-auth.
+*
+* (c) Sean Tymon <tymon148@gmail.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
 namespace Tymon\JWTAuth\Providers\Auth;
 
 use Tymon\JWTAuth\Contracts\Providers\Auth;
 use LaravelDoctrine\ORM\Auth\DoctrineUserProvider;
 
 /**
- * Class Doctrine
+ * Class Doctrine.
  *
  * @package Tymon\JWTAuth\Providers\Auth
  * @author James Kirkby <me@jameskirkby.com>
@@ -46,11 +55,13 @@ class Doctrine implements Auth
 
     /**
      * @param mixed $id
+     * 
      * @return mixed
      */
     public function byId($id)
     {
         $this->user = $this->doctrineUserAdapter->retrieveById($id);
+        
         return $this->user;
     }
 
@@ -61,5 +72,4 @@ class Doctrine implements Auth
     {
         return $this->user;
     }
-
 }

--- a/src/Providers/Auth/Doctrine.php
+++ b/src/Providers/Auth/Doctrine.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tymon\JWTAuth\Providers\Auth;
+
+use Tymon\JWTAuth\Contracts\Providers\Auth;
+use LaravelDoctrine\ORM\Auth\DoctrineUserProvider;
+
+/**
+ * Class Doctrine
+ *
+ * @package Tymon\JWTAuth\Providers\Auth
+ * @author James Kirkby <me@jameskirkby.com>
+ */
+class Doctrine implements Auth
+{
+
+    /**
+     * @var DoctrineUserProvider
+     */
+    protected $doctrineUserAdapter;
+
+    /**
+     * @var
+     */
+    protected $user;
+
+    /**
+     * DoctrineUserAdapter constructor.
+     *
+     * @param DoctrineUserProvider $doctrineUserProvider
+     */
+    public function __construct(DoctrineUserProvider $doctrineUserProvider)
+    {
+        $this->doctrineUserAdapter = $doctrineUserProvider;
+    }
+
+    /**
+     * @param array $credentials
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function byCredentials(array $credentials)
+    {
+        $this->user = $this->doctrineUserAdapter->retrieveByCredentials($credentials);
+        return $this->user;
+    }
+
+    /**
+     * @param mixed $id
+     * @return mixed
+     */
+    public function byId($id)
+    {
+        $this->user = $this->doctrineUserAdapter->retrieveById($id);
+        return $this->user;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function user()
+    {
+        return $this->user;
+    }
+
+}


### PR DESCRIPTION
I've added an adapter to hook into laravel doctrines auth provider, it seems alot more people are using laravel doctrine now and seen a few more issues in the queue regarding implentation.

It does require a service provider like so 

    /**
     * Register any application services.
     *
     * @return void
     */
    public function register()
    {
        $this->app->bind(DoctrineUserAdapter::class, function($app) {
            return new DoctrineUserAdapter(
                new DoctrineUserProvider(
                    $app['hash'],
                    $app['em'],
                    User::class
                )
            );
        });
    }

But i didn't know where to put this in the application as you wouldn't want to globally bind doctrine for people who aren't using it.