### PR TITLE
Use \Illuminate\Support\Str::random.

### DIFF
--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -77,6 +77,6 @@ class JWTGenerateSecretCommand extends Command
      */
     protected function getRandomKey()
     {
-        return Str::quickRandom(32);
+        return Str::random(32);
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -207,7 +207,7 @@ class Factory
      */
     protected function jti()
     {
-        return md5(sprintf('%s.%s', $this->claims->toJson(), Str::quickRandom()));
+        return md5(sprintf('%s.%s', $this->claims->toJson(), Str::random()));
     }
 
     /**


### PR DESCRIPTION
Use `\Illuminate\Support\Str::random` - `\Illuminate\Support\Str::quickRandom` is deprecated since `5.3`