### PR TITLE
Fix authorisation header being discarded by laravel

### DIFF
--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -53,13 +53,13 @@ class AuthHeaders implements ParserContract
     {
         $header = $request->headers->get($this->header) ?: $this->fromAltHeaders($request);
 
-        if(is_null($header)) {
-         $headers = array_change_key_case(getallheaders(), CASE_LOWER);
+        if (is_null($header)) {
+            $headers = array_change_key_case(getallheaders(), CASE_LOWER);
 
-         if(array_key_exists($this->header, $headers)) {
-           $header = $headers[$this->header];
-         }
-       }
+            if (array_key_exists($this->header, $headers)) {
+                $header = $headers[$this->header];
+            }
+        }
 
         if ($header && stripos($header, $this->prefix) === 0) {
             return trim(str_ireplace($this->prefix, '', $header));

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -53,6 +53,14 @@ class AuthHeaders implements ParserContract
     {
         $header = $request->headers->get($this->header) ?: $this->fromAltHeaders($request);
 
+        if(is_null($header)) {
+         $headers = array_change_key_case(getallheaders(), CASE_LOWER);
+
+         if(array_key_exists($this->header, $headers)) {
+           $header = $headers[$this->header];
+         }
+       }
+
         if ($header && stripos($header, $this->prefix) === 0) {
             return trim(str_ireplace($this->prefix, '', $header));
         }


### PR DESCRIPTION
By default, Laravel/Lumen are discarding the Authorisation Bearer token of the headers.
At this moment, this should be fixed by adding `RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]`to the htaccess. As this is not in the docs, it it confusing for some people.

This pull request gets the header with php functions when the one from Laravel is empty and tries to fix the error that way. Hope this is useful. Fix based on a previous comment from @jeroenbourgois.

Any feedback is very welcome!

Update: will try and fix the tests.
