### PR TITLE
- Fix: Refreshing Expired token fail with option refresh_ttl enabled

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -84,7 +84,7 @@ class Manager
         $payloadArray = $this->provider->decode($token->get());
 
         $payload = $this->payloadFactory
-                        ->setRefreshFlow($this->refreshFlow)
+                        ->setRefreshFlow()
                         ->customClaims($payloadArray)
                         ->make();
 


### PR DESCRIPTION
When refresh_ttl Enabled , Refresh expired  token will fail with exception TokenExpiredException