### PR TITLE
Issue #877: Accept other fields for id instead of subject

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -157,6 +157,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Identifier Claim Field
+    |--------------------------------------------------------------------------
+    |
+    | Specify the field to be used by JWTAuth for determining the unique
+    | identifier. Usually this is 'sub', but Firebase and other services
+    | may use another field, like 'uid'.
+    */
+
+    'identifier_claim_field' => env('JWT_IDENTIFIER_CLAIM_FIELD', 'sub'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Blacklist Enabled
     |--------------------------------------------------------------------------
     |

--- a/src/Contracts/JWTSubject.php
+++ b/src/Contracts/JWTSubject.php
@@ -14,7 +14,7 @@ namespace Tymon\JWTAuth\Contracts;
 interface JWTSubject
 {
     /**
-     * Get the identifier that will be stored in the subject claim of the JWT.
+     * Get the identifier that will be stored in the identifier field claim of the JWT.
      *
      * @return mixed
      */

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -201,8 +201,9 @@ class JWT
      */
     protected function getClaimsArray(JWTSubject $user)
     {
+        $identifier_field = config('jwt.identifier_claim_field', 'sub');
         return array_merge(
-            ['sub' => $user->getJWTIdentifier()],
+            [$identifier_field => $user->getJWTIdentifier()],
             $this->customClaims, // custom claims from inline setter
             $user->getJWTCustomClaims() // custom claims from JWTSubject method
         );

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -57,7 +57,8 @@ class JWTAuth extends JWT
      */
     public function authenticate()
     {
-        $id = $this->getPayload()->get('sub');
+        $identifier_field = config('jwt.identifier_claim_field', 'sub');
+        $id = $this->getPayload()->get($identifier_field);
 
         if (! $this->auth->byId($id)) {
             return false;

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -73,7 +73,8 @@ class JWTGuard implements Guard
         }
 
         if ($this->jwt->getToken() && $this->jwt->check()) {
-            $id = $this->jwt->payload()->get('sub');
+            $identifier_field = config('jwt.identifier_claim_field', 'sub');
+            $id = $this->jwt->payload()->get($identifier_field);
 
             return $this->user = $this->provider->retrieveById($id);
         }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -113,9 +113,10 @@ class Manager
         $payload = $this->setRefreshFlow()->decode($token, false);
 
         // persist the subject and issued at claims
+        $identifier_field = config('jwt.identifier_claim_field', 'sub');
         $claims = array_merge(
             $this->customClaims,
-            ['sub' => $payload['sub'], 'iat' => $payload['iat']]
+            [$identifier_field => $payload[$identifier_field], 'iat' => $payload['iat']]
         );
 
         // return the new token


### PR DESCRIPTION
I don't really like the duplication of the config() calls, but this was the general gist and a quick test with my login and with passing the token I get to firebase seems to work, but there may be more code needed to persist the 'sub' field anyway even if it's not the identifier field anymore?

Also FWIW, to work with firebase, I had to set JWT_ALGO to RS256, and set JWT_PUBLIC_KEY to a file path (\n's in .env don't seem to work) and a JWT_PRIVATE_KEY with a file:// path, and JWT_TTL to 30 minutes (3600 is the Firebase max).

Setting the new JWT_IDENTIFIER_CLAIM_FIELD env to 'uid' and my getJwtCusomClaims() to
```
	public function getJWTCustomClaims()
	{
		return [
			'iss' => '******@appspot.gserviceaccount.com',
			'sub' => '******@appspot.gserviceaccount.com',
			'aud' => 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
			'uid' => $this->getKey()
		];
	}
```

seems to get me up and going... I fully understand if this isn't the way you wish to implement.