### PR TITLE
Fix for refresh token flow. Blacklisting token occurs before refresh token is generated invalidating token for refresh flow.

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -105,12 +105,12 @@ class Manager
      */
     public function refresh(Token $token, $forceForever = false)
     {
+        $payload = $this->setRefreshFlow()->decode($token, false);
+
         if ($this->blacklistEnabled) {
             // invalidate old token
             $this->invalidate($token, $forceForever);
         }
-
-        $payload = $this->setRefreshFlow()->decode($token, false);
 
         // persist the subject and issued at claims
         $claims = array_merge(


### PR DESCRIPTION
Fixes #808 
