### PR TITLE
Reset claims collection when creating a payload.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -69,7 +69,10 @@ class Factory
      */
     public function make()
     {
-        return $this->withClaims($this->buildClaimsCollection());
+        $payload = $this->withClaims($this->buildClaimsCollection());
+        $this->claims = new Collection;
+
+        return $payload;
     }
 
     /**


### PR DESCRIPTION
This fixes an issue I've been having when using this library, specifically when writing tests with it.

The use case is that I create a token with some custom claims and then later want refresh the token and remove one of the claims.

For example if I use the following code
```php
<?php
/** @var JWTAuth $auth */
$auth = $this->app[JWTAuth::class];
$user = factory(User::class)->make();

$token = $auth->claims(['foo' => 'bar', 'baz' => 'qux'])
    ->fromUser($user);

dump($auth->setToken($token)->getPayload()->get());

$token = $auth->claims(['foo' => 'bar'])
    ->refresh();

dump($auth->setToken($token)->getPayload()->get());
```

I get the following output:
```
array:8 [
  "iss" => "http://:"
  "iat" => 1479501277
  "exp" => 1479504877
  "nbf" => 1479501277
  "jti" => "f48235a527b19245c2ade2937f2d4a04"
  "sub" => null
  "foo" => "bar"
  "baz" => "qux"
]
array:8 [
  "iss" => "http://:"
  "iat" => 1479501277
  "exp" => 1479504877
  "nbf" => 1479501277
  "jti" => "d2d9b3509c05474014f113b9eb37345a"
  "sub" => null
  "foo" => "bar"
  "baz" => "qux"
]
```

What I would expect is that the latter array to not have the `"baz"` key whatsoever, as I have specified a new set of custom claims.