### PR TITLE
Blacklist sends NULL to Carbon

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -118,10 +118,15 @@ class Blacklist
     public function has(Payload $payload)
     {
         $val = $this->storage->get($this->getKey($payload));
-
-        // exit early if the token was blacklisted forever
+        
+        // exit early if the token was blacklisted forever, 
         if ($val === 'forever') {
             return true;
+        }
+        
+        // exit with false if key isn't found
+        if ($val === null || empty($val)) {
+            return false;
         }
 
         // check whether the expiry + grace has past


### PR DESCRIPTION
If the key in `has` method isn't found, `Utils::isFuture` will send a NULL value to Carbon who will throw an exception. Can happen if storage doesn't find a blacklist key.