### PR TITLE
Add Laravel 5.4 compatibility

### DIFF
--- a/src/Providers/JWTAuthServiceProvider.php
+++ b/src/Providers/JWTAuthServiceProvider.php
@@ -119,8 +119,11 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerUserProvider()
     {
-        $this->app['tymon.jwt.provider.user'] = $this->app->share(function ($app) {
-            return $app->make($this->config('providers.user'), [$app->make($this->config('user'))]);
+        $this->app->singleton('tymon.jwt.provider.user', function ($app) {
+            $provider = $this->config('providers.user');
+            $model = $app->make($this->config('user'));
+
+            return new $provider($model);
         });
     }
 
@@ -129,12 +132,12 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerJWTProvider()
     {
-        $this->app['tymon.jwt.provider.jwt'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.provider.jwt', function ($app) {
             $secret = $this->config('secret');
             $algo = $this->config('algo');
             $provider = $this->config('providers.jwt');
 
-            return $app->make($provider, [$secret, $algo]);
+            return new $provider($secret, $algo);
         });
     }
 
@@ -143,7 +146,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerAuthProvider()
     {
-        $this->app['tymon.jwt.provider.auth'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.provider.auth', function ($app) {
             return $this->getConfigInstance($this->config('providers.auth'));
         });
     }
@@ -153,7 +156,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerStorageProvider()
     {
-        $this->app['tymon.jwt.provider.storage'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.provider.storage', function ($app) {
             return $this->getConfigInstance($this->config('providers.storage'));
         });
     }
@@ -173,7 +176,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerJWTManager()
     {
-        $this->app['tymon.jwt.manager'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.manager', function ($app) {
             $instance = new JWTManager(
                 $app['tymon.jwt.provider.jwt'],
                 $app['tymon.jwt.blacklist'],
@@ -189,7 +192,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerJWTAuth()
     {
-        $this->app['tymon.jwt.auth'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.auth', function ($app) {
             $auth = new JWTAuth(
                 $app['tymon.jwt.manager'],
                 $app['tymon.jwt.provider.user'],
@@ -206,7 +209,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerJWTBlacklist()
     {
-        $this->app['tymon.jwt.blacklist'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.blacklist', function ($app) {
             $instance = new Blacklist($app['tymon.jwt.provider.storage']);
 
             return $instance->setRefreshTTL($this->config('refresh_ttl'));
@@ -218,7 +221,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerPayloadValidator()
     {
-        $this->app['tymon.jwt.validators.payload'] = $this->app->share(function () {
+        $this->app->singleton('tymon.jwt.validators.payload', function () {
             return with(new PayloadValidator())->setRefreshTTL($this->config('refresh_ttl'))->setRequiredClaims($this->config('required_claims'));
         });
     }
@@ -228,7 +231,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerPayloadFactory()
     {
-        $this->app['tymon.jwt.payload.factory'] = $this->app->share(function ($app) {
+        $this->app->singleton('tymon.jwt.payload.factory', function ($app) {
             $factory = new PayloadFactory($app['tymon.jwt.claim.factory'], $app['request'], $app['tymon.jwt.validators.payload']);
 
             return $factory->setTTL($this->config('ttl'));
@@ -240,7 +243,7 @@ class JWTAuthServiceProvider extends ServiceProvider
      */
     protected function registerJWTCommand()
     {
-        $this->app['tymon.jwt.generate'] = $this->app->share(function () {
+        $this->app->singleton('tymon.jwt.generate', function () {
             return new JWTGenerateCommand();
         });
     }


### PR DESCRIPTION
Laravel 5.4 removed the `share()` method as well the option to pass an array of parameters to `make()`.
This pull request fixes both of this in the JWTAuthServiceProvider