### PR TITLE
fix LaravelServiceProvider for L 5.4

### DIFF
--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -28,10 +28,17 @@ class LaravelServiceProvider extends AbstractServiceProvider
         $this->publishes([$path => config_path('jwt.php')], 'config');
         $this->mergeConfigFrom($path, 'jwt');
 
-        $this->app['router']->middleware('jwt.auth', Authenticate::class);
-        $this->app['router']->middleware('jwt.refresh', RefreshToken::class);
-        $this->app['router']->middleware('jwt.renew', AuthenticateAndRenew::class);
-        $this->app['router']->middleware('jwt.check', Check::class);
+        if (method_exists($this->app['router'], 'aliasMiddleware')) {
+            $this->app['router']->aliasMiddleware('jwt.auth', Authenticate::class);
+            $this->app['router']->aliasMiddleware('jwt.refresh', RefreshToken::class);
+            $this->app['router']->aliasMiddleware('jwt.renew', AuthenticateAndRenew::class);
+            $this->app['router']->aliasMiddleware('jwt.check', Check::class);
+        } else {
+            $this->app['router']->middleware('jwt.auth', Authenticate::class);
+            $this->app['router']->middleware('jwt.refresh', RefreshToken::class);
+            $this->app['router']->middleware('jwt.renew', AuthenticateAndRenew::class);
+            $this->app['router']->middleware('jwt.check', Check::class);
+        }
 
         $this->extendAuthGuard();
     }


### PR DESCRIPTION
In Laravel 5.4 there is now a aliasMiddleware method that does what the middleware function did before.  I do an if statement check so the middleware will be compatible with previous versions of Laravel 5 as well.  This is a fix for issue #972