### PR TITLE
Suggest HTTP-status-code 498 like ArcGIS

### DIFF
--- a/src/Exceptions/TokenExpiredException.php
+++ b/src/Exceptions/TokenExpiredException.php
@@ -11,6 +11,8 @@
 
 namespace Tymon\JWTAuth\Exceptions;
 
+use Exception;
+
 class TokenExpiredException extends JWTException
 {
     /**

--- a/src/Exceptions/TokenExpiredException.php
+++ b/src/Exceptions/TokenExpiredException.php
@@ -13,5 +13,16 @@ namespace Tymon\JWTAuth\Exceptions;
 
 class TokenExpiredException extends JWTException
 {
-    //
+    /**
+     * @param  string  $message default: 'Token Expired'
+     * @param  int  $code default: 498
+     * @param  \Exception|null  $previous default: null
+     *
+     * @return void
+     */
+    public function __construct($message = 'Token Expired', $code = 498, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
 }

--- a/src/Exceptions/TokenExpiredException.php
+++ b/src/Exceptions/TokenExpiredException.php
@@ -24,5 +24,4 @@ class TokenExpiredException extends JWTException
     {
         parent::__construct($message, $code, $previous);
     }
-
 }


### PR DESCRIPTION
I would like to suggest to use http-status-code 498, like ArcGIS seems to do for tokens.
«498 Invalid Token (Esri)
Returned by ArcGIS for Server. A code of 498 indicates an expired or otherwise invalid token.[69]
» ~ https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#cite_ref-arcgis_70-0 , http://help.arcgis.com/en/arcgisserver/10.0/apis/soap/index.htm#Using_token_authentication.htm .