### PR TITLE
Throw if user no longer exists in authentication middleware

### DIFF
--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -66,9 +66,13 @@ abstract class BaseMiddleware
         $this->checkForToken($request);
 
         try {
-            $this->auth->parseToken()->authenticate();
+            $user = $this->auth->parseToken()->authenticate();
         } catch (JWTException $e) {
             throw new UnauthorizedHttpException('jwt-auth', $e->getMessage(), $e, $e->getCode());
+        }
+
+        if (! $user) {
+            throw new UnauthorizedHttpException('jwt-auth', 'User not found');
         }
     }
 }

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -102,4 +102,22 @@ class AuthenticateTest extends AbstractTestCase
         $this->middleware->handle($this->request, function () {
         });
     }
+
+    /**
+     * @test
+     * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
+     */
+    public function it_should_throw_an_unauthorized_exception_if_user_not_found()
+    {
+        $parser = Mockery::mock(Parser::class);
+        $parser->shouldReceive('hasToken')->once()->andReturn(true);
+
+        $this->auth->shouldReceive('parser')->andReturn($parser);
+
+        $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(false);
+
+        $this->middleware->handle($this->request, function () {
+        });
+    }
 }


### PR DESCRIPTION
Currently, in the 1.0 branch, the auth middleware will not throw an exception if the JWT token is valid, but the user in the `sub` claim no longer exists. This functionality existed in pre-1.0 versions.

In previous versions, this threw a 404, however I believe a 401 is more appropriate.

It may also be worth invalidating the token in such cases, but I didn't add it into this PR.