### PR TITLE
Let the first letter capitalize

### DIFF
--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -28,7 +28,7 @@ class AuthHeaders implements ParserContract
      *
      * @var string
      */
-    protected $prefix = 'bearer';
+    protected $prefix = 'Bearer';
 
     /**
      * Attempt to parse the token from some other possible headers.

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -21,7 +21,7 @@ class AuthHeaders implements ParserContract
      *
      * @var string
      */
-    protected $header = 'authorization';
+    protected $header = 'Authorization';
 
     /**
      * The header prefix.


### PR DESCRIPTION
After read https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html, I think maybe we should make the authorization header first letter capitalize.
