### PR TITLE
Correct status code for missing auth tokens

### DIFF
--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -48,7 +48,7 @@ abstract class BaseMiddleware
     public function checkForToken(Request $request)
     {
         if (! $this->auth->parser()->setRequest($request)->hasToken()) {
-            throw new BadRequestHttpException('Token not provided');
+            throw new UnauthorizedHttpException('Token not provided');
         }
     }
 

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -14,7 +14,6 @@ namespace Tymon\JWTAuth\Http\Middleware;
 use Tymon\JWTAuth\JWTAuth;
 use Illuminate\Http\Request;
 use Tymon\JWTAuth\Exceptions\JWTException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 abstract class BaseMiddleware

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -76,7 +76,7 @@ class AuthenticateAndRenewTest extends AbstractTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      */
     public function it_should_throw_a_bad_request_exception_if_token_not_provided()
     {

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -71,7 +71,7 @@ class AuthenticateTest extends AbstractTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      */
     public function it_should_throw_a_bad_request_exception_if_token_not_provided()
     {

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -74,7 +74,7 @@ class RefreshTokenTest extends AbstractTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      */
     public function it_should_throw_a_bad_request_exception_if_token_not_provided()
     {


### PR DESCRIPTION
This was discussed in https://github.com/tymondesigns/jwt-auth/issues/1024

`400` represents a mal-formed request.

`401` is specifically for use when authentication is required or has not yet been provided.