### PR TITLE
invalidate the old token AFTER building the claim

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -113,13 +113,13 @@ class Manager
     {
         $this->setRefreshFlow();
 
+        $claims = $this->buildRefreshClaims($this->decode($token));
+
         if ($this->blacklistEnabled) {
             // invalidate old token
             $this->invalidate($token, $forceForever);
         }
-
-        $claims = $this->buildRefreshClaims($this->decode($token));
-
+        
         // return the new token
         return $this->encode(
             $this->payloadFactory->customClaims($claims)->make($resetClaims)


### PR DESCRIPTION
After the fix for issue #1060 the refresh middleware stopped working because it would check the blacklist and then fail because the token is already invalidated.  If you move the invalidation til after the "buildRefreshClaims" method then you don't have this problem.