### PR TITLE
change to a token invalid exception

### DIFF
--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -12,7 +12,6 @@
 namespace Tymon\JWTAuth\Claims;
 
 use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
 class IssuedAt extends Claim
@@ -52,7 +51,7 @@ class IssuedAt extends Claim
     public function validateRefresh($refreshTTL)
     {
         if ($this->isPast($this->getValue() + $refreshTTL * 60)) {
-            throw new TokenExpiredException('Token has expired and can no longer be refreshed');
+            throw new TokenInvalidException('Token has expired and can no longer be refreshed');
         }
     }
 }

--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -12,6 +12,7 @@
 namespace Tymon\JWTAuth\Claims;
 
 use Tymon\JWTAuth\Exceptions\InvalidClaimException;
+use Tymon\JWTAuth\Exceptions\RefreshTokenExpiredException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
 class IssuedAt extends Claim
@@ -51,7 +52,7 @@ class IssuedAt extends Claim
     public function validateRefresh($refreshTTL)
     {
         if ($this->isPast($this->getValue() + $refreshTTL * 60)) {
-            throw new TokenInvalidException('Token has expired and can no longer be refreshed');
+            throw new RefreshTokenExpiredException('Token has expired and can no longer be refreshed');
         }
     }
 }

--- a/src/Exceptions/RefreshTokenExpiredException.php
+++ b/src/Exceptions/RefreshTokenExpiredException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Exceptions;
+
+class RefreshTokenExpiredException extends TokenExpiredException
+{
+    //
+}


### PR DESCRIPTION
After the fix for #1060 and the subsequent pull request, I found another issue I hope you will consider.

As it stands right now, the refresh functionality is hard to use.  

When I navigate to an endpoint with an expired token I get a TokenExpiredException, this lets me know that I need to refresh the token.  I then hit the refresh endpoint and as it stands currently will either 1) refresh the token, or 2) give me another TokenExpiredException with the message "Token has expired and can no longer be refreshed".  It should return something else like an invalid token exception etc.  

As it currently stands I can't tell the difference between an expired token that can be refreshed, and an expired token that cannot be refreshed.  The only way I can tell the difference is by looking at the error message.  This seems hacky and improper since the message could change with any push to the repo.