### PR TITLE
Allow null prv claim.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -279,7 +279,11 @@ class JWT
      */
     public function checkProvider($provider)
     {
-        return $this->hashProvider($provider) === $this->payload()->get('prv');
+        if (is_null($prv = $this->payload()->get('prv'))) {
+            return true;
+        }
+
+        return $this->hashProvider($provider) === $prv;
     }
 
     /**

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -96,6 +96,20 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
+    public function it_should_pass_provider_check_if_hash_matches_when_provider_is_null()
+    {
+        $payloadFactory = Mockery::mock(Factory::class);
+        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+        $payloadFactory->shouldReceive('get')
+                       ->with('prv')
+                       ->andReturnNull();
+
+        $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
+
+        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkProvider('Tymon\JWTAuth\Test\Stubs\UserStub'));
+    }
+
+    /** @test */
     public function it_should_not_pass_provider_check_if_hash_not_match()
     {
         $payloadFactory = Mockery::mock(Factory::class);


### PR DESCRIPTION
This allows JWT token created before tymondesigns/jwt-auth#1167 can be
used until TTL is expired. Would be useful instead of logout everyone since the token failed
checkProvider().

Signed-off-by: crynobone <crynobone@gmail.com>