### PR TITLE
Use SHA1 instead of MD5.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -267,7 +267,7 @@ class JWT
      */
     protected function hashProvider($provider)
     {
-        return md5(is_object($provider) ? get_class($provider) : $provider);
+        return sha1(is_object($provider) ? get_class($provider) : $provider);
     }
 
     /**

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -71,7 +71,7 @@ class JWTAuthTest extends AbstractTestCase
         $this->manager
              ->shouldReceive('getPayloadFactory->customClaims')
              ->once()
-             ->with(['sub' => 1, 'prv' => md5('Tymon\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
+             ->with(['sub' => 1, 'prv' => sha1('Tymon\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
              ->andReturn($payloadFactory);
 
         $this->manager->shouldReceive('encode->get')->once()->andReturn('foo.bar.baz');
@@ -88,7 +88,7 @@ class JWTAuthTest extends AbstractTestCase
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
                        ->with('prv')
-                       ->andReturn(md5('Tymon\JWTAuth\Test\Stubs\UserStub'));
+                       ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub'));
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
 
@@ -116,7 +116,7 @@ class JWTAuthTest extends AbstractTestCase
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
                        ->with('prv')
-                       ->andReturn(md5('Tymon\JWTAuth\Test\Stubs\UserStub1'));
+                       ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub1'));
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
 
@@ -132,7 +132,7 @@ class JWTAuthTest extends AbstractTestCase
         $this->manager
              ->shouldReceive('getPayloadFactory->customClaims')
              ->once()
-             ->with(['sub' => 1, 'prv' => md5('Tymon\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
+             ->with(['sub' => 1, 'prv' => sha1('Tymon\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
              ->andReturn($payloadFactory);
 
         $this->manager->shouldReceive('encode->get')->once()->andReturn('foo.bar.baz');


### PR DESCRIPTION
Using `md5` to encode the `prv` claim (which is readable clear) seems a bit weak as there are many ways to reverse it - I believe that no one wants to provide too much details about which model is used for authentication.