### PR TITLE
Use get method instead of query

### DIFF
--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -200,7 +200,7 @@ class JWTAuth
     public function parseToken($method = 'bearer', $header = 'authorization', $query = 'token')
     {
         if (! $token = $this->parseAuthHeader($header, $method)) {
-            if (! $token = $this->request->query($query, false)) {
+            if (! $token = $this->request->get($query, false)) {
                 throw new JWTException('The token could not be parsed from the request', 400);
             }
         }


### PR DESCRIPTION
When we use query method token should pass as query string and in many cases we post token with form inputs thats why even if you passed valid token you got token_not_provided