### PR TITLE
on refresh update the token

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -97,7 +97,7 @@ class JWT
 
         $this->token = $this->manager->customClaims($this->getCustomClaims())
                              ->refresh($this->token, $forceForever, $resetClaims);
-        
+
         return $this->token->get();
     }
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -95,9 +95,10 @@ class JWT
     {
         $this->requireToken();
 
-        return $this->manager->customClaims($this->getCustomClaims())
-                             ->refresh($this->token, $forceForever, $resetClaims)
-                             ->get();
+        $this->token = $this->manager->customClaims($this->getCustomClaims())
+                             ->refresh($this->token, $forceForever, $resetClaims);
+        
+        return $this->token->get();
     }
 
     /**


### PR DESCRIPTION
This is to prevent the blacklist exception on payload retrieval.

(If the token is refresh at the start of the request, then there will be a blacklist exception on getPayload)