### PR TITLE
Add handle method for Secret Generator Command

### DIFF
--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -33,6 +33,16 @@ class JWTGenerateSecretCommand extends Command
     protected $description = 'Set the JWTAuth secret key used to sign the tokens';
 
     /**
+     * This method deligates to Laravel 5.5 would look for 
+     * "handle" method instead of fire
+     * @return void
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void


### PR DESCRIPTION
Laravel 5.5 is looking for the handle method instead of fire. "handle" method would call "fire" method.