### PR TITLE
Simplify illuminate package versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,18 +24,18 @@
     ],
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "illuminate/auth": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
-        "illuminate/contracts": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
-        "illuminate/http": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/auth": "^5.1",
+        "illuminate/contracts": "^5.1",
+        "illuminate/http": "^5.1",
+        "illuminate/support": "^5.1",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^1.0"
     },
     "require-dev": {
         "cartalyst/sentinel": "2.0.*",
-        "illuminate/console": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
-        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
-        "illuminate/routing": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/console": "^5.1",
+        "illuminate/database": "^5.1",
+        "illuminate/routing": "^5.1",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.8 || ~6.0"
     },


### PR DESCRIPTION
To avoid putting `||` for each new version.