### PR TITLE
Fix getModel not found error.

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -74,7 +74,7 @@ class JWTGuard implements Guard
 
         if ($this->jwt->setRequest($this->request)->getToken() &&
             ($payload = $this->jwt->check(true)) &&
-            $this->jwt->checkProvider($this->provider->getModel())
+            $this->jwt->checkProvider($this->provider)
         ) {
             return $this->user = $this->provider->retrieveById($payload['sub']);
         }


### PR DESCRIPTION
There may be a mistake here, getModel method does not have to in the class that implement UserProvider.