### PR TITLE
Exceptions caught and raised accordingly

### DIFF
--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -43,9 +43,8 @@ class Check extends BaseMiddleware
                     throw new TokenBlacklistedException();
                 } elseif ($exception instanceof PayloadException) {
                     throw new PayloadException();
-                } else {
-                    throw new JWTException('unknown issue');
                 }
+                throw new JWTException('unknown issue');
             }
         } else {
             throw new JWTException('no token');

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -13,6 +13,11 @@ namespace Tymon\JWTAuth\Http\Middleware;
 
 use Closure;
 use Exception;
+use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Exceptions\PayloadException;
+use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
 class Check extends BaseMiddleware
 {
@@ -30,8 +35,20 @@ class Check extends BaseMiddleware
             try {
                 $this->auth->parseToken()->authenticate();
             } catch (Exception $e) {
-                //
+                if ($exception instanceof TokenInvalidException) {
+                    throw new TokenInvalidException();
+                } elseif ($exception instanceof TokenExpiredException) {
+                    throw new TokenExpiredException();
+                } elseif ($exception instanceof TokenBlacklistedException) {
+                    throw new TokenBlacklistedException();
+                } elseif ($exception instanceof PayloadException) {
+                    throw new PayloadException();
+                } else {
+                   throw new JWTException('unknown issue');
+                }
             }
+        }else {
+            throw new JWTException('no token');
         }
 
         return $next($request);

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -44,10 +44,10 @@ class Check extends BaseMiddleware
                 } elseif ($exception instanceof PayloadException) {
                     throw new PayloadException();
                 }
-                throw new JWTException('unknown issue');
+                throw new JWTException('unknown_issue');
             }
         } else {
-            throw new JWTException('no token');
+            throw new JWTException('no_token');
         }
 
         return $next($request);

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -15,9 +15,9 @@ use Closure;
 use Exception;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Exceptions\PayloadException;
-use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
 use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
 
 class Check extends BaseMiddleware
 {
@@ -47,7 +47,7 @@ class Check extends BaseMiddleware
                    throw new JWTException('unknown issue');
                 }
             }
-        }else {
+        } else {
             throw new JWTException('no token');
         }
 

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -43,9 +43,8 @@ class Check extends BaseMiddleware
                     throw new TokenBlacklistedException();
                 } elseif ($exception instanceof PayloadException) {
                     throw new PayloadException();
-                } else {
-                   throw new JWTException('unknown issue');
-                }
+                } 
+                throw new JWTException('unknown issue');
             }
         } else {
             throw new JWTException('no token');

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -44,10 +44,10 @@ class Check extends BaseMiddleware
                 } elseif ($exception instanceof PayloadException) {
                     throw new PayloadException();
                 }
-                throw new JWTException('unknown_issue');
+                throw new JWTException('unknown error occured');
             }
         } else {
-            throw new JWTException('no_token');
+            throw new JWTException('no token provided');
         }
 
         return $next($request);

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -43,8 +43,9 @@ class Check extends BaseMiddleware
                     throw new TokenBlacklistedException();
                 } elseif ($exception instanceof PayloadException) {
                     throw new PayloadException();
-                } 
-                throw new JWTException('unknown issue');
+                } else {
+                    throw new JWTException('unknown issue');
+                }
             }
         } else {
             throw new JWTException('no token');


### PR DESCRIPTION
The exceptions can be handled in exception handler class whenever the middleware is brought to use before 'auth' middleware. Useful in Lumen 5.5 as the normal response from auth middleware is a HTTP 401 without any description.