### PR TITLE
Remove some require dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,18 +24,11 @@
     ],
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "illuminate/auth": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
-        "illuminate/contracts": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
-        "illuminate/http": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^1.0"
     },
     "require-dev": {
         "cartalyst/sentinel": "2.0.*",
-        "illuminate/console": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
-        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
-        "illuminate/routing": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.8 || ~6.0"
     },


### PR DESCRIPTION
The required Illuminate/* packages are now a part of laravel/framework