### PR TITLE
feat: decrypt cookies during parsing

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -202,6 +202,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cookies encryption
+    |--------------------------------------------------------------------------
+    |
+    | By default Laravel encrypt cookies for security reason.
+    | If you decide to not decrypt cookies, you will have to configure Laravel
+    | to not encrypt your cookie token by adding its name into the $except
+    | array available in the middleware "EncryptCookies" provided by Laravel.
+    | see https://laravel.com/docs/master/responses#cookies-and-encryption
+    | for details.
+    |
+    | Set it to false if you don't want to decrypt cookies.
+    |
+    */
+    'decrypt_cookies' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Providers
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Parser/Cookies.php
+++ b/src/Http/Parser/Cookies.php
@@ -12,11 +12,24 @@
 namespace Tymon\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
 use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
 
 class Cookies implements ParserContract
 {
     use KeyTrait;
+
+    /**
+     * Decrypt or not the cookie while parsing.
+     *
+     * @var bool
+     */
+    private $decrypt;
+
+    public function __construct($decrypt = true)
+    {
+        $this->decrypt = $decrypt;
+    }
 
     /**
      * Try to parse the token from the request cookies.
@@ -27,6 +40,10 @@ class Cookies implements ParserContract
      */
     public function parse(Request $request)
     {
+        if ($this->decrypt) {
+            return Crypt::decrypt($request->cookie($this->key));
+        }
+
         return $request->cookie($this->key);
     }
 }

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -197,7 +197,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
                     new QueryString,
                     new InputSource,
                     new RouteParams,
-                    new Cookies,
+                    new Cookies($this->config('decrypt_cookies')),
                 ]
             );
 


### PR DESCRIPTION
Hi, since Laravel encrypt cookies by default, currently if you don't tell Laravel to not encrypt your cookie token (https://laravel.com/docs/5.5/responses#cookies-and-encryption), the parsing will fail.

This PR add an option to decrypt or not cookies which is by default enabled to follow Laravel behavior.

Note: it's a breaking change for those who currently added their cookie in the except middleware array.

Thank you