### PR TITLE
Added handle() method to JWTGenerateCommand

### DIFF
--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -32,6 +32,15 @@ class JWTGenerateSecretCommand extends Command
      */
     protected $description = 'Set the JWTAuth secret key used to sign the tokens';
 
+      /**
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        return $this->fire();
+
+    }
     /**
      * Execute the console command.
      *


### PR DESCRIPTION
When generating the jwt I got a  ``` [ReflectionException]
  Method Tymon\JWTAuth\Commands\JWTGenerateCommand::handle() does not exist```  added ```handle()``` method to call ```fire()```