### PR TITLE
Only try to decrypt the cookie if the cookie actually exists.

### DIFF
--- a/src/Http/Parser/Cookies.php
+++ b/src/Http/Parser/Cookies.php
@@ -40,7 +40,7 @@ class Cookies implements ParserContract
      */
     public function parse(Request $request)
     {
-        if ($this->decrypt) {
+        if ($this->decrypt && $request->hasCookie($this->key)) {
             return Crypt::decrypt($request->cookie($this->key));
         }
 


### PR DESCRIPTION
Pull Request [#1363](https://github.com/tymondesigns/jwt-auth/pull/1363) decrypts the cookie while parsing.

But it also tries to decrypt the cookie when it doesn't exists, which results in an Exception from the Decrypter.

This PR changes that so that it only tries to decrypt the cookie if it actually exists.

Fixes: [#1372](https://github.com/tymondesigns/jwt-auth/issues/1372)