### PR TITLE
Adjusted regex to allow comma-seperated tokens in the Authorization h…

### DIFF
--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -53,7 +53,7 @@ class AuthHeaders implements ParserContract
     {
         $header = $request->headers->get($this->header) ?: $this->fromAltHeaders($request);
 
-        if ($header && preg_match('/'.$this->prefix.'\s*(.*)\b/i', $header, $matches)) {
+        if ($header && preg_match('/'.$this->prefix.'\s*(\S+)\b/i', $header, $matches)) {
             return $matches[1];
         }
     }


### PR DESCRIPTION
The current regex does not find the prefixed token if more than one item is in the authorization header as it captures everything including the comma to separate. This regex change will find the prefixed token even if it is not the only token in the Authorization header.

This feature would be useful for developers making a system that requires both an API key(for application level authentication and authorization) and a Token(for user level authentication and authorization).

Thank you for the great authentication tool!