### PR TITLE
Make getToken() try to parse request only the first time

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -154,11 +154,11 @@ class JWT
      */
     public function getToken()
     {
-        if (! $this->token) {
+        if ($this->token === NULL) {
             try {
                 $this->parseToken();
             } catch (JWTException $e) {
-                return false;
+                $this->token = false;
             }
         }
 


### PR DESCRIPTION
In the case of absent/invalid token avoid to try to parse the request every time getToken() is called by parsing it only the first time and saving the result of it.

The return behavior is unchanged