### PR TITLE
Check if email was sent in login request

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -135,7 +135,7 @@ class AuthController extends Controller
     {
         $credentials = request(['email', 'password']);
 
-        if (! $token = $this->guard()->attempt($credentials)) {
+        if (! isset($credentials['email']) || ! $token = $this->guard()->attempt($credentials)) {
             return response()->json(['error' => 'Unauthorized'], 401);
         }
 


### PR DESCRIPTION
The AuthController from quick start allows to login if the email is not sent and if the password matches the first user from the database.

For example, the following post do `/login` will try to login with the first user found in database:
```json
{
	"password": "{{ password  }}"
}
```

Which generates the following SQL:
```
select * from user limit 1
```

This PR ensures that the email was sent in the request. If not, then 401.