### PR TITLE
Cookie decryption now set to false by default

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -212,11 +212,11 @@ return [
     | see https://laravel.com/docs/master/responses#cookies-and-encryption
     | for details.
     |
-    | Set it to false if you don't want to decrypt cookies.
+    | Set it to true if you want to decrypt cookies.
     |
     */
 
-    'decrypt_cookies' => true,
+    'decrypt_cookies' => false,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Cookie encryption is enabled by default in some frameworks such as Laravel.

Enabling encryption by default will cause invalid payload exceptions where double encryption is attempted.

Therefore i have set this to false to get round such issues.

