### PR TITLE
Rename `fire` method to `handle`

### DIFF
--- a/src/Commands/JWTGenerateCommand.php
+++ b/src/Commands/JWTGenerateCommand.php
@@ -36,7 +36,7 @@ class JWTGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $key = $this->getRandomKey();
 


### PR DESCRIPTION
This PR renames the `JWTGenerateCommand::fire` to `handle` as it is required by Laravel 5.5.

Please note that this DOES NOT break backwards compatibility as Laravel versions prior to v5.5 supported both `fire` and `handle` methods.