### PR TITLE
Increase specificity of JWTGuard::getRequest() return type

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -342,7 +342,7 @@ class JWTGuard implements Guard
     /**
      * Get the current request instance.
      *
-     * @return \Symfony\Component\HttpFoundation\Request
+     * @return \Illuminate\Http\Request
      */
     public function getRequest()
     {


### PR DESCRIPTION
This PR makes the documented return type of `JWTGuard::getRequest()` consistent with the other occurrences of `Illuminate\Http\Request`. Currently the set request code in `JWTGuard::requireToken()` (amongst other places) appears incorrect at first glance because of the discrepancy.

This is a safe change as `Illuminate\Http\Request::createFromGlobals` returns type `static` (despite deferring to the parent class for this method).