### PR TITLE
possible fix for #340

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -301,6 +301,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     {
         $this->app->singleton('tymon.jwt.validators.payload', function () {
             return (new PayloadValidator)
+                ->setTTL($this->config('ttl'))
                 ->setRefreshTTL($this->config('refresh_ttl'))
                 ->setRequiredClaims($this->config('required_claims'));
         });

--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -38,6 +38,13 @@ class PayloadValidator extends Validator
     protected $refreshTTL = 20160;
 
     /**
+     * The TTL.
+     *
+     * @var int
+     */
+    protected $ttl = 60;
+
+    /**
      * Run the validations on the payload array.
      *
      * @param  \Tymon\JWTAuth\Claims\Collection  $value
@@ -63,7 +70,7 @@ class PayloadValidator extends Validator
      */
     protected function validateStructure(Collection $claims)
     {
-        if (! $claims->hasAllClaims($this->requiredClaims)) {
+        if (! $claims->hasAllClaims($this->getRequiredClaims())) {
             throw new TokenInvalidException('JWT payload does not contain the required claims');
         }
     }
@@ -112,6 +119,21 @@ class PayloadValidator extends Validator
     }
 
     /**
+     * Get the required claims.
+     *
+     * @return array
+     */
+    public function getRequiredClaims()
+    {
+        $requiredClaims = $this->requiredClaims;
+        if ($this->ttl === null && $key = array_search('exp', $requiredClaims)) {
+            unset($requiredClaims[$key]);
+        }
+
+        return $requiredClaims;
+    }
+
+    /**
      * Set the refresh ttl.
      *
      * @param  int  $ttl
@@ -121,6 +143,20 @@ class PayloadValidator extends Validator
     public function setRefreshTTL($ttl)
     {
         $this->refreshTTL = $ttl;
+
+        return $this;
+    }
+
+    /**
+     * Set the refresh ttl.
+     *
+     * @param  int  $ttl
+     *
+     * @return $this
+     */
+    public function setTTL($ttl)
+    {
+        $this->ttl = $ttl;
 
         return $this;
     }


### PR DESCRIPTION
There is an issue when env variable JWT_TTL is set to null - this is because PayloadValidator expects all claim keys form it's own class properties
related to #340 