### PR TITLE
Fix jwt:generate failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 build
+/.idea/

--- a/src/Commands/JWTGenerateCommand.php
+++ b/src/Commands/JWTGenerateCommand.php
@@ -36,7 +36,7 @@ class JWTGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $key = $this->getRandomKey();
 


### PR DESCRIPTION
Fixed the issue where php artisan jwt:generate was failing in Laravel 5.5