### PR TITLE
Add JWT::flushToken() method

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -51,6 +51,13 @@ class JWT
     protected $lockSubject = true;
 
     /**
+     * Indicates if the parser should attempt to parse a new token when $this->token is null.
+     *
+     * @var bool
+     */
+    protected $flushToken = false;
+
+    /**
      * JWT constructor.
      *
      * @param  \Tymon\JWTAuth\Manager  $manager
@@ -161,7 +168,7 @@ class JWT
      */
     public function getToken()
     {
-        if ($this->token === null) {
+        if ($this->token === null && ! $this->flushToken) {
             try {
                 $this->parseToken();
             } catch (JWTException $e) {
@@ -302,6 +309,7 @@ class JWT
     public function setToken($token)
     {
         $this->token = $token instanceof Token ? $token : new Token($token);
+        $this->flushToken = false;
 
         return $this;
     }
@@ -316,6 +324,18 @@ class JWT
         $this->token = null;
 
         return $this;
+    }
+
+    /**
+     * Unset the current token and make sure it's not automatically set again.
+     *
+     * @return $this
+     */
+    public function flushToken()
+    {
+        $this->flushToken = true;
+
+        return $this->unsetToken();
     }
 
     /**

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -317,6 +317,28 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
+    public function if_the_token_has_been_flushed_it_should_not_try_to_parse_from_the_request()
+    {
+        $this->parser->shouldNotReceive('parseToken');
+        $token = new Token('foo.bar.baz');
+        $this->jwtAuth->setToken($token);
+
+        $this->jwtAuth->flushToken();
+        $this->assertNull($this->jwtAuth->getToken());
+    }
+
+    /** @test */
+    public function it_returns_a_token_if_it_has_been_set_after_being_flushed()
+    {
+        $this->parser->shouldNotReceive('parseToken');
+        $this->jwtAuth->flushToken();
+
+        $token = new Token('foo.bar.baz');
+        $this->jwtAuth->setToken($token);
+        $this->assertSame('foo.bar.baz', $this->jwtAuth->getToken()->get());
+    }
+
+    /** @test */
     public function it_should_get_the_manager_instance()
     {
         $manager = $this->jwtAuth->manager();


### PR DESCRIPTION
Enables the token to be unset and ensures it will not be automatically parsed from the request etc. later on in the code.

I have a use-case where a user makes a request to an endpoint with a JWT, which is parsed and then they're logged in with jwt-auth and a new token issued. Currently I cannot unset the first token because it's just re-parsed from the request during `JWTGuard::attempt()` so I get an exception `You must unsign before making changes`.

Not sure if this is the best way to solve, open to feedback!