### PR TITLE
Fixed command to generate a key not working laravel version less than 5.4.17

### DIFF
--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -108,6 +108,11 @@ class JWTGenerateSecretCommand extends Command
             return $this->laravel->environmentFilePath();
         }
 
+        // check if laravel version Less than 5.4.17
+        if (version_compare($this->laravel->version(), '5.4.17', '<')) {
+            return $this->laravel->basePath() . DIRECTORY_SEPARATOR . '.env';
+        }
+
         return $this->laravel->basePath('.env');
     }
 }


### PR DESCRIPTION
Fixed command to generate a key not working in laravel version less than 5.4.17