### PR TITLE
Adding configurable header name and method.

### DIFF
--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -44,6 +44,16 @@ class JWTAuth
     protected $identifier = 'id';
 
     /**
+     * @var string
+     */
+    protected $header;
+
+    /**
+     * @var string
+     */
+    protected $header_method;
+
+    /**
      * @var \Tymon\JWTAuth\Token
      */
     protected $token;
@@ -60,6 +70,8 @@ class JWTAuth
         $this->user = $user;
         $this->auth = $auth;
         $this->request = $request;
+        $this->header = config('jwt.header');
+        $this->header_method = config('jwt.header_method');
     }
 
     /**
@@ -197,8 +209,11 @@ class JWTAuth
      *
      * @return JWTAuth
      */
-    public function parseToken($method = 'bearer', $header = 'authorization', $query = 'token')
+    public function parseToken($method = null, $header = null, $query = 'token')
     {
+        if (empty($method)) $method = $this->header_method;
+        if (empty($header)) $header = $this->header;
+
         if (! $token = $this->parseAuthHeader($header, $method)) {
             if (! $token = $this->request->query($query, false)) {
                 throw new JWTException('The token could not be parsed from the request', 400);
@@ -216,8 +231,11 @@ class JWTAuth
      *
      * @return false|string
      */
-    protected function parseAuthHeader($header = 'authorization', $method = 'bearer')
+    protected function parseAuthHeader($header = null, $method = null)
     {
+        if (empty($method)) $method = $this->header_method;
+        if (empty($header)) $header = $this->header;
+
         $header = $this->request->headers->get($header);
 
         if (! starts_with(strtolower($header), $method)) {

--- a/src/Middleware/RefreshToken.php
+++ b/src/Middleware/RefreshToken.php
@@ -36,7 +36,7 @@ class RefreshToken extends BaseMiddleware
         }
 
         // send the refreshed token back to the client
-        $response->headers->set('Authorization', 'Bearer '.$newToken);
+        $response->headers->set(config('jwt.header'), config('jwt.header_method').' '.$newToken);
 
         return $response;
     }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -40,10 +40,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Header name
+    | Header method
     |--------------------------------------------------------------------------
     |
-    | By default the Auth header name is Authorization.
+    | By default the Auth header method is bearer.
     | You can set it to a custom one if you are using HTTP BASIC AUTH with
     | JWT Authorization for example. Otherwise you will get a conflict in
     | Authorization Headers.

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -25,6 +25,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Header name
+    |--------------------------------------------------------------------------
+    |
+    | By default the Auth header name is Authorization.
+    | You can set it to a custom one if you are using HTTP BASIC AUTH with
+    | JWT Authorization for example. Otherwise you will get a conflict in
+    | Authorization Headers.
+    |
+    */
+
+    'header' => env('JWT_HEADER', 'authorization'),
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Header name
+    |--------------------------------------------------------------------------
+    |
+    | By default the Auth header name is Authorization.
+    | You can set it to a custom one if you are using HTTP BASIC AUTH with
+    | JWT Authorization for example. Otherwise you will get a conflict in
+    | Authorization Headers.
+    |
+    */
+
+    'header_method' => env('JWT_HEADER_METHOD', 'bearer'),
+
+    /*
+    |--------------------------------------------------------------------------
     | JWT time to live
     |--------------------------------------------------------------------------
     |

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -164,7 +164,7 @@ class JWTAuthTest extends \PHPUnit_Framework_TestCase
     public function it_should_retrieve_the_token_from_the_auth_header()
     {
         $request = Request::create('/foo', 'GET');
-        $request->headers->set('authorization', 'Bearer foo.bar.baz');
+        $request->headers->set(config('jwt.header'), config('jwt.header_method').' foo.bar.baz');
         $jwtAuth = new JWTAuth($this->manager, $this->user, $this->auth, $request);
 
         $this->assertInstanceOf('Tymon\JWTAuth\Token', $jwtAuth->parseToken()->getToken());


### PR DESCRIPTION
 In case someone uses HTTP_BASIC AUTH under development and needs JWT implementation the headers are not working well together. This commit fixes it as it makes the headers and header_method configurable.