### PR TITLE
Added JWTProvider facade

### DIFF
--- a/src/Facades/JWTProvider.php
+++ b/src/Facades/JWTProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class JWTProvider extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'tymon.jwt.provider.jwt';
+    }
+}


### PR DESCRIPTION
Hello,

I was looking forward to use same library for emails validations too but could not find a clean way to easly generate tokens outside of auth. After some search and thinking I came up with this PR, and I hope many are going to find specific uses of this in their projects!

Use-case example:

```php
use JWTProvider;

$payload = ['email' => 'customer@domain.com', 'referred_by' => 12];
$token = JWTProvider::encode($payload);

// we e-mail a confirmation link with the generated token to "customer@domain.com"

```

```php
use JWTProvider;

try {
    $payload = JWTProvider::decode($token);
} catch (Exception $e) {

}

// after token being validated, we could finalize the registration process

```


Thank you for a great work you did with this library! Keep up the good work.