### PR TITLE
make lock_subject config available for JWTAuth

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -269,11 +269,11 @@ abstract class AbstractServiceProvider extends ServiceProvider
     protected function registerJWTAuth()
     {
         $this->app->singleton('tymon.jwt.auth', function ($app) {
-            return new JWTAuth(
+            return (new JWTAuth(
                 $app['tymon.jwt.manager'],
                 $app['tymon.jwt.provider.auth'],
                 $app['tymon.jwt.parser']
-            );
+            ))->lockSubject($this->config('lock_subject'));
         });
     }
 


### PR DESCRIPTION
I like use `JWTAuth::fromUser($u);` to generate jwt token, this pull request makes `lock_subject` config makes effect.