### PR TITLE
Make JWTAuth respect the "lock_subject" setting in the config file

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -269,11 +269,11 @@ abstract class AbstractServiceProvider extends ServiceProvider
     protected function registerJWTAuth()
     {
         $this->app->singleton('tymon.jwt.auth', function ($app) {
-            return new JWTAuth(
+            return (new JWTAuth(
                 $app['tymon.jwt.manager'],
                 $app['tymon.jwt.provider.auth'],
                 $app['tymon.jwt.parser']
-            );
+            ))->lockSubject($this->config('lock_subject'));
         });
     }
 


### PR DESCRIPTION
I noticed that tokens generated via the JWTAuth facade still had the "prv" claim attached to them, regardless of the "lock_subject" setting in the configuration file. I've altered the instantiation of JWTAuth in the service provider so that it calls lockSubject() immediately on the instance (matching the procedure used for JWT earlier in the file).