### PR TITLE
Wrong casing

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -96,7 +96,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     protected function extendAuthGuard()
     {
         $this->app['auth']->extend('jwt', function ($app, $name, array $config) {
-            $guard = new JwtGuard(
+            $guard = new JWTGuard(
                 $app['tymon.jwt'],
                 $app['auth']->createUserProvider($config['provider']),
                 $app['request']


### PR DESCRIPTION
Class imported as `Tymon\JWTAuth\JWTGuard` but referenced as `JwtGuard`, which create errors when running in HHVM.