### PR TITLE
Update the defaults as no required claims

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -142,17 +142,17 @@ return [
     |
     | Specify the required claims that must exist in any token.
     | A TokenInvalidException will be thrown if any of these claims are not
-    | present in the payload.
+    | present in the payload. By default, there are no required claims.
     |
     */
 
     'required_claims' => [
-        'iss',
-        'iat',
-        'exp',
-        'nbf',
-        'sub',
-        'jti',
+        // 'iss',
+        // 'iat',
+        // 'exp',
+        // 'nbf',
+        // 'sub',
+        // 'jti',
     ],
 
     /*


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7519#section-4.1 , the Registered Claim Names are mandatory. Note that this PR has not been tested.