### PR TITLE
Decode token string only one time.

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -70,6 +70,9 @@ class Manager
         $this->provider = $provider;
         $this->blacklist = $blacklist;
         $this->payloadFactory = $payloadFactory;
+
+        Token::setJwtProvider($this->provider);
+        Token::setPayloadFactory($this->payloadFactory);
     }
 
     /**
@@ -81,9 +84,7 @@ class Manager
      */
     public function encode(Payload $payload)
     {
-        $token = $this->provider->encode($payload->get());
-
-        return new Token($token);
+        return new Token($payload);
     }
 
     /**
@@ -98,12 +99,7 @@ class Manager
      */
     public function decode(Token $token, $checkBlacklist = true)
     {
-        $payloadArray = $this->provider->decode($token->get());
-
-        $payload = $this->payloadFactory
-                        ->setRefreshFlow($this->refreshFlow)
-                        ->customClaims($payloadArray)
-                        ->make();
+        $payload = $token->getPayload($this->refreshFlow);
 
         if ($checkBlacklist && $this->blacklistEnabled && $this->blacklist->has($payload)) {
             throw new TokenBlacklistedException('The token has been blacklisted');

--- a/src/Token.php
+++ b/src/Token.php
@@ -70,6 +70,7 @@ class Token
      * Get the payload.
      *
      * @param bool $refreshFlow
+     *
      * @return array|Payload
      */
     public function getPayload($refreshFlow)

--- a/src/Token.php
+++ b/src/Token.php
@@ -59,7 +59,7 @@ class Token
      */
     public function get()
     {
-        if (is_null($this->value)) {
+        if (null === $this->value) {
             $this->value = self::$jwtProvider->encode($this->payload->toArray());
         }
 
@@ -74,7 +74,7 @@ class Token
      */
     public function getPayload($refreshFlow)
     {
-        if (is_null($this->payload)) {
+        if (null === $this->payload) {
             $payloadArray = self::$jwtProvider->decode($this->value);
 
             $this->payload = self::$payloadFactory->setRefreshFlow($refreshFlow)
@@ -96,7 +96,7 @@ class Token
     }
 
     /**
-     * Set jwt provider
+     * Set jwt provider.
      *
      * @param \Tymon\JWTAuth\Contracts\Providers\JWT $provider
      */
@@ -106,7 +106,7 @@ class Token
     }
 
     /**
-     * Set payload factory
+     * Set payload factory.
      *
      * @param \Tymon\JWTAuth\Factory $factory
      */

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -170,7 +170,7 @@ class ManagerTest extends AbstractTestCase
         $payload = new Payload($collection, $this->validator);
         $token = new Token('foo.bar.baz');
 
-        $this->jwt->shouldReceive('decode')->twice()->with('foo.bar.baz')->andReturn($payload->toArray());
+        $this->jwt->shouldReceive('decode')->once()->with('foo.bar.baz')->andReturn($payload->toArray());
         $this->jwt->shouldReceive('encode')->with($payload->toArray())->andReturn('baz.bar.foo');
 
         $this->factory->shouldReceive('setRefreshFlow')->with(true)->andReturn($this->factory);


### PR DESCRIPTION
The `Token` and `Payload` objects have a high cohesion. Make the `Token` object has a `Payload` property, we just need decode it only one time and use it in many places.