### PR TITLE
Update `iat` claim when refreshing token

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -175,7 +175,7 @@ class Manager
         // persist the relevant claims
         return array_merge(
             $this->customClaims,
-            compact($this->persistentClaims, 'sub', 'iat')
+            compact($this->persistentClaims, 'sub')
         );
     }
 


### PR DESCRIPTION
Update `iat` claim when refreshing token. If not, when the `refresh_ttl` is expired, users have to login again even though they use the app every day uninterruptedly.
Please note that it will extend the token life. If you refresh token again and again, you can get a never expiring token. If the `refresh_ttl` is expired, it couldn't be refreshed, the user must login again.

I think this behavior is more applicable to the actual situation. If worry about some break changes, let me know, maybe we can add another method, like `renew`, and let developers choose it according to their preferences.