### PR TITLE
Fix security bug in `JWTAuth::authenticate`

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -285,11 +285,13 @@ class JWT
      */
     public function checkSubjectModel($model)
     {
-        if (($prv = $this->payload()->get('prv')) === null) {
-            return true;
+        $prv = $this->payload()->get('prv');
+
+        if ($this->lockSubject || null !== $prv) {
+            return $this->hashSubjectModel($model) === $prv;
         }
 
-        return $this->hashSubjectModel($model) === $prv;
+        return true;
     }
 
     /**

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -61,13 +61,9 @@ class JWTAuth extends JWT
      */
     public function authenticate()
     {
-        $id = $this->getPayload()->get('sub');
+        $user = $this->user();
 
-        if (! $this->auth->byId($id)) {
-            return false;
-        }
-
-        return $this->user();
+        return null === $user ? false : $user;
     }
 
     /**

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -180,23 +180,17 @@ class JWTAuthTest extends AbstractTestCase
 
     /**
      * @test
-     * @expectedException \Tymon\JWTAuth\Exceptions\JWTException
-     * @expectedExceptionMessage A token is required
      */
-    public function it_should_throw_an_exception_when_not_providing_a_token()
+    public function it_should_return_false_when_not_providing_a_token()
     {
-        $this->jwtAuth->toUser();
+        $this->auth->shouldReceive('user')->once()->andReturnNull();
+
+        $this->assertFalse($this->jwtAuth->toUser());
     }
 
     /** @test */
     public function it_should_return_the_owning_user_from_a_token_containing_an_existing_user()
     {
-        $payload = Mockery::mock(Payload::class);
-        $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
-
-        $this->manager->shouldReceive('decode')->once()->andReturn($payload);
-
-        $this->auth->shouldReceive('byId')->once()->with(1)->andReturn(true);
         $this->auth->shouldReceive('user')->once()->andReturn((object) ['id' => 1]);
 
         $user = $this->jwtAuth->setToken('foo.bar.baz')->customClaims(['foo' => 'bar'])->authenticate();
@@ -207,13 +201,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_return_false_when_passing_a_token_not_containing_an_existing_user()
     {
-        $payload = Mockery::mock(Payload::class);
-        $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
-
-        $this->manager->shouldReceive('decode')->once()->andReturn($payload);
-
-        $this->auth->shouldReceive('byId')->once()->with(1)->andReturn(false);
-        $this->auth->shouldReceive('user')->never();
+        $this->auth->shouldReceive('user')->once()->andReturnNull();
 
         $user = $this->jwtAuth->setToken('foo.bar.baz')->authenticate();
 

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -77,13 +77,16 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_pass_provider_check_if_hash_matches()
     {
+        $payload = Mockery::mock(Payload::class);
         $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
-        $payloadFactory->shouldReceive('get')
-                       ->with('prv')
-                       ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub'));
 
-        $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
+        $payloadFactory->shouldReceive('make')->andReturn($payload);
+
+        $payload->shouldReceive('get')
+                ->with('prv')
+                ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub'));
+
+        $this->manager->shouldReceive('decode')->once()->andReturn($payload);
 
         $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
     }
@@ -91,13 +94,16 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_pass_provider_check_if_hash_matches_when_provider_is_null()
     {
+        $payload = Mockery::mock(Payload::class);
         $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
-        $payloadFactory->shouldReceive('get')
-                       ->with('prv')
-                       ->andReturnNull();
 
-        $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
+        $payloadFactory->shouldReceive('make')->andReturn($payload);
+
+        $payload->shouldReceive('get')
+                ->with('prv')
+                ->andReturnNull();
+
+        $this->manager->shouldReceive('decode')->once()->andReturn($payload);
 
         $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
     }
@@ -105,13 +111,16 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_not_pass_provider_check_if_hash_not_match()
     {
+        $payload = Mockery::mock(Payload::class);
         $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
-        $payloadFactory->shouldReceive('get')
-                       ->with('prv')
-                       ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub1'));
 
-        $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
+        $payloadFactory->shouldReceive('make')->andReturn($payload);
+
+        $payload->shouldReceive('get')
+                ->with('prv')
+                ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub1'));
+
+        $this->manager->shouldReceive('decode')->once()->andReturn($payload);
 
         $this->assertFalse($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
     }
@@ -119,8 +128,10 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_return_a_token_when_passing_valid_credentials_to_attempt_method()
     {
+        $payload = Mockery::mock(Payload::class);
         $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+
+        $payloadFactory->shouldReceive('make')->andReturn($payload);
 
         $this->manager
              ->shouldReceive('getPayloadFactory->customClaims')

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -92,7 +92,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_pass_provider_check_if_hash_matches_when_provider_is_null()
+    public function it_should_pass_provider_check_if_hash_matches_when_provider_is_null_without_lock_subject()
     {
         $payload = Mockery::mock(Payload::class);
         $payloadFactory = Mockery::mock(Factory::class);
@@ -105,7 +105,24 @@ class JWTAuthTest extends AbstractTestCase
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payload);
 
-        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
+        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->lockSubject(false)->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
+    }
+
+    /** @test */
+    public function it_should_not_pass_provider_check_if_hash_matches_when_provider_is_null_with_lock_subject()
+    {
+        $payload = Mockery::mock(Payload::class);
+        $payloadFactory = Mockery::mock(Factory::class);
+
+        $payloadFactory->shouldReceive('make')->andReturn($payload);
+
+        $payload->shouldReceive('get')
+            ->with('prv')
+            ->andReturnNull();
+
+        $this->manager->shouldReceive('decode')->once()->andReturn($payload);
+
+        $this->assertFalse($this->jwtAuth->setToken('foo.bar.baz')->lockSubject(true)->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
     }
 
     /** @test */
@@ -246,7 +263,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_authenticated_user()
+    public function it_should_get_the_manager()
     {
         $manager = $this->jwtAuth->manager();
         $this->assertInstanceOf(Manager::class, $manager);


### PR DESCRIPTION
`JWTAuth::authenticate` must to check the user's subject model. If not, we can use user's token to get admin's ability.

# Reproduce
Create a Laravel Project with `App\User` and `App\Admin` models. Config `config/auth.php` file, as below, for demonstration purposes the default guard is "admin".
``` php
return [
    'defaults' => [
        'guard' => 'admin',
    ],
    'guards' => [
        'api' => [
            'driver' => 'jwt',
            'provider' => 'users',
        ],
        'admin' => [
            'driver' => 'jwt',
            'provider' => 'admins',
        ],
    ],
    'providers' => [
        'users' => [
            'driver' => 'eloquent',
            'model' => App\User::class,
        ],
        'admins' => [
            'driver' => 'eloquent',
            'model' => App\Admin::class,
        ],
    ]
];
```
Run code in `php artisan tinker`
``` php
$userToken = auth('api')->tokenById(1);
app('tymon.jwt.auth')->setToken($userToken)->authenticate();  // Error: Get the admin's info
```

# Fix
Check user's subject model.

After fix:
``` php
$userToken = auth('api')->tokenById(1);
app('tymon.jwt.auth')->setToken($userToken)->authenticate();  // return false
```