### PR TITLE
Refactor middleware, inspired by `Illuminate\Auth\Middleware\Authenticate`

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -123,6 +123,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Refresh period
+    |--------------------------------------------------------------------------
+    |
+    | Refresh token automatically by server when clients access. It works in
+    | the `jwt.renew` middleware.
+    | Set the period in seconds that the token can be refreshed automatically
+    | before expiring. Defaults to 1 day.
+    |
+    | You can also set this to 0, to refresh every request.
+    | But this is not particularly recommended.
+    |
+    */
+
+    'refresh_period' => env('JWT_REFRESH_PERIOD', 3600 * 24),
+
+    /*
+    |--------------------------------------------------------------------------
     | JWT hashing algorithm
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -20,6 +20,13 @@ use Tymon\JWTAuth\JWTGuard;
 class AuthenticateAndRenew
 {
     /**
+     * Refresh period in seconds.
+     *
+     * @var int
+     */
+    public $refreshPeriod;
+
+    /**
      * The authentication factory instance.
      *
      * @var \Illuminate\Contracts\Auth\Factory
@@ -96,7 +103,7 @@ class AuthenticateAndRenew
      */
     protected function setAuthenticationHeader($response, $guard)
     {
-        $period = config('jwt.refresh_period');
+        $period = $this->getRefreshPeriod();
         $expire = $guard->getPayload()->get('exp');
 
         if (! $expire || ($period && $expire - time() > $period)) {
@@ -112,5 +119,19 @@ class AuthenticateAndRenew
         }
 
         return $response;
+    }
+
+    /**
+     * Get refresh period.
+     *
+     * @return int
+     */
+    protected function getRefreshPeriod()
+    {
+        if (null === $this->refreshPeriod) {
+            $this->refreshPeriod = intval(config('jwt.refresh_period'));
+        }
+
+        return $this->refreshPeriod;
     }
 }

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -41,9 +41,10 @@ class AuthenticateAndRenew
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string[]  ...$guards
-     * @return mixed
      *
      * @throws \Illuminate\Auth\AuthenticationException
+     *
+     * @return mixed
      */
     public function handle($request, Closure $next, ...$guards)
     {
@@ -64,9 +65,10 @@ class AuthenticateAndRenew
      * Determine if the user is logged in to any of the given guards.
      *
      * @param  array  $guards
-     * @return void
      *
      * @throws \Illuminate\Auth\AuthenticationException
+     *
+     * @return void
      */
     protected function authenticate(array $guards)
     {

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -14,6 +14,7 @@ namespace Tymon\JWTAuth\Http\Middleware;
 use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\JWTGuard;
 
 class AuthenticateAndRenew
@@ -95,7 +96,12 @@ class AuthenticateAndRenew
      */
     protected function setAuthenticationHeader($response, $guard)
     {
-        $token = $guard->refresh();
+        try {
+            $token = $guard->refresh();
+        } catch (TokenExpiredException $e) {
+            return $response;
+        }
+
         $response->headers->set('Authorization', "Bearer {$token}");
 
         return $response;

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -12,10 +12,10 @@
 namespace Tymon\JWTAuth\Http\Middleware;
 
 use Closure;
-use Illuminate\Auth\AuthenticationException;
-use Illuminate\Contracts\Auth\Factory as AuthFactory;
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\JWTGuard;
+use Illuminate\Auth\AuthenticationException;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 
 class AuthenticateAndRenew
 {

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -11,12 +11,12 @@
 
 namespace Tymon\JWTAuth\Test\Middleware;
 
-use Illuminate\Auth\AuthenticationException;
-use Illuminate\Contracts\Auth\Factory as AuthFactory;
-use Illuminate\Http\Response;
 use Mockery;
 use Tymon\JWTAuth\JWTGuard;
+use Illuminate\Http\Response;
 use Tymon\JWTAuth\Test\Stubs\UserStub;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Tymon\JWTAuth\Http\Middleware\AuthenticateAndRenew;
 
 class AuthenticateAndRenewTest extends AbstractMiddlewareTest


### PR DESCRIPTION
The old `AuthenticateAndRenew` is not based the `guard` concept, it may have a little problem without `jwt` driver.
The new one is more compatible with the `auth` middleware, it has the same behavior. If the guard driver is `jwt`, it will automatically refresh the token. Just like its original behavior.
I test it in Laravel 5.6.24. It's the same as the default `auth` middleware's usage: "jwt.renew", "jwt.renew:{$guard}", like "jwt.renew:api", "jwt.renew:admin".

By the way, I think we don't need other middleware, like `Authenticate`, `Check` and `RefreshToken`. They seem not very useful. 
So that we can rename `AuthenticateAndRenew` to `Authenticate`. And add a feature for limiting the frequency of automatic refresh to control it more meticulous.
Any ideas please let me know.