### PR TITLE
Adding macroable capabilities to the Guard

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -16,13 +16,16 @@ use Illuminate\Http\Request;
 use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
 use Tymon\JWTAuth\Contracts\JWTSubject;
+use Illuminate\Support\Traits\Macroable;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Illuminate\Contracts\Auth\UserProvider;
 use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
 
 class JWTGuard implements Guard
 {
-    use GuardHelpers;
+    use GuardHelpers, Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The user we last attempted to retrieve.
@@ -433,6 +436,10 @@ class JWTGuard implements Guard
     {
         if (method_exists($this->jwt, $method)) {
             return call_user_func_array([$this->jwt, $method], $parameters);
+        }
+
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
         }
 
         throw new BadMethodCallException("Method [$method] does not exist.");

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -486,4 +486,17 @@ class JWTGuardTest extends AbstractTestCase
         $this->jwt->shouldReceive('getPayload')->once()->andReturn(Mockery::mock(Payload::class));
         $this->assertInstanceOf(Payload::class, $this->guard->payload());
     }
+
+    /**
+     * @test
+     * @group laravel-5.2
+     */
+    public function it_should_be_macroable()
+    {
+        $this->guard->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals('bar', $this->guard->foo());
+    }
 }


### PR DESCRIPTION
Laravel's Guard classes are macroable; adding the same capability to the JWTGuard gives to possibility to _extend_ the class at runtime.