### PR TITLE
Don't reset blacklist expiration time

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -71,6 +71,11 @@ class Blacklist
             return $this->addForever($payload);
         }
 
+        // if we have already added this token to the blacklist
+        if (! empty($this->storage->get($this->getKey($payload)))) {
+            return true;
+        }
+
         $this->storage->add(
             $this->getKey($payload),
             ['valid_until' => $this->getGraceTimestamp()],

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -74,6 +74,10 @@ class BlacklistTest extends AbstractTestCase
             ->with('foo', ['valid_until' => $this->testNowTimestamp], $refreshTTL + 1)
             ->once();
 
+        $this->storage->allows('get')
+            ->with($this->blacklist->getKey($payload))
+            ->once();
+
         $this->blacklist->setRefreshTTL($refreshTTL)->add($payload);
     }
 
@@ -118,6 +122,10 @@ class BlacklistTest extends AbstractTestCase
 
         $this->storage->shouldReceive('add')
             ->with('foo', ['valid_until' => $this->testNowTimestamp], $refreshTTL + 1)
+            ->once();
+
+        $this->storage->allows('get')
+            ->with($this->blacklist->getKey($payload))
             ->once();
 
         $this->assertTrue($this->blacklist->setRefreshTTL($refreshTTL)->add($payload));


### PR DESCRIPTION
Currently, a blacklisted token can be used for an infinite amount of time when using the blacklist grace period, so long as a request is made at least once every x seconds (where x is the value of `blacklist_grace_period`).

This change ensures that the reset time on a blacklisted token is not reset every time a request is made.