### PR TITLE
Refresh custom claims from the subject when a token is refreshed

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -102,7 +102,7 @@ class JWT
     {
         $this->requireToken();
 
-        return $this->manager->customClaims($this->getCustomClaims())
+        return $this->manager->customClaims($this->getClaimsArray($this->authenticate()))
                              ->refresh($this->token, $forceForever, $resetClaims)
                              ->get();
     }


### PR DESCRIPTION
Fixes #891 

Currently when you refresh a token, it does not regenerate the custom claims data. If for example data in my `getJWTCustomClaims` is dynamic the only way the token gets updated is with a new login.
This change will recreate the claims array properly for refreshed tokens as well.

(Apologies if this is the wrong way to do it, happy to discuss other solutions)