### PR TITLE
(#1622) Properly documented the public JWTAuth\Manager methods JWTAuth exposes.

### DIFF
--- a/src/Facades/JWTAuth.php
+++ b/src/Facades/JWTAuth.php
@@ -11,8 +11,30 @@
 
 namespace Tymon\JWTAuth\Facades;
 
+use Tymon\JWTAuth\Token;
+use Tymon\JWTAuth\Manager;
+use Tymon\JWTAuth\Payload;
+use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\Claims\Factory;
 use Illuminate\Support\Facades\Facade;
+use Tymon\JWTAuth\Contracts\Providers\JWT as Provider;
 
+/**
+ * List all of the public methods of JWTAuth\Manager, since this class exposes them
+ * via composition.
+ *
+ * @method static Token   encode(Payload $payload)
+ * @method static Payload decode(Token $token, bool $checkBlacklist = true)
+ * @method Factory   getPayloadFactory()
+ * @method Provider  getJWTProvider()
+ * @method Blacklist getBlacklist()
+ * @method bool      setBlacklistEnabled($enabled)
+ * @method Manager   setPersistentClaims(array $claims)
+ * @method Manager   customClaims(array $customClaims)
+ * @method Manager   claims(array $customClaims)
+ * @method array     getCustomClaims()
+ * @method Manager   setRefreshFlow($refreshFlow = true)
+ */
 class JWTAuth extends Facade
 {
     /**

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -17,7 +17,24 @@ use Tymon\JWTAuth\Http\Parser\Parser;
 use Tymon\JWTAuth\Contracts\JWTSubject;
 use Tymon\JWTAuth\Support\CustomClaims;
 use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Contracts\Providers\JWT as Provider;
 
+/**
+ * List all of the public methods of JWTAuth\Manager, since this class exposes them
+ * via composition.
+ *
+ * @method Token     encode(Payload $payload)
+ * @method Payload   decode(Token $token, bool $checkBlacklist = true)
+ * @method Factory   getPayloadFactory()
+ * @method Provider  getJWTProvider()
+ * @method Blacklist getBlacklist()
+ * @method bool      setBlacklistEnabled($enabled)
+ * @method Manager   setPersistentClaims(array $claims)
+ * @method Manager   customClaims(array $customClaims)
+ * @method Manager   claims(array $customClaims)
+ * @method array     getCustomClaims()
+ * @method Manager   setRefreshFlow($refreshFlow = true)
+ */
 class JWT
 {
     use CustomClaims;


### PR DESCRIPTION
## The Problem

When running phpstan/phpstan on a project which uses JWTAuth, errors are dutifully reported because JWTAuth also exposes all of the public methods of `JWTAuth\Manager`, without properly documenting in the class docblock that it does so.

```php
$token = JWTAuth::decode(JWTAuth::getToken())->toArray();
```
**PHP Stan reports it as an error:**
```
 ------ -----------------------------------------------------------------------------
  Line   app/Http/Controllers/AuthenticateController.php
 ------ -----------------------------------------------------------------------------
  165    Call to an undefined static method Tymon\JWTAuth\Facades\JWTAuth::decode().
 ------ -----------------------------------------------------------------------------
```
![image](https://user-images.githubusercontent.com/1125541/42651531-43f6450e-85d5-11e8-989a-1f8cdc454ee4.png)

Properly document that JWTAuth\JWTAuth exposes every public function of JWTAuth\Manager and the two traits it uses.

For #1622.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tymondesigns/jwt-auth/1623)
<!-- Reviewable:end -->
