### PR TITLE
Fixing bug in jwt.refresh middleware

### DIFF
--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -36,6 +36,8 @@ class RefreshToken extends BaseMiddleware
         } catch (JWTException $e) {
             throw new UnauthorizedHttpException('jwt-auth', $e->getMessage(), $e, $e->getCode());
         }
+        
+        $request->merge(compact('token'));
 
         $response = $next($request);
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -98,7 +98,7 @@ class Manager
      */
     public function decode(Token $token, $checkBlacklist = true)
     {
-        $payloadArray = $this->provider->decode($token->get());
+        $payloadArray = $this->provider->decode((Input::get('token')? Input::get('token') :$token->get()));
 
         $payload = $this->payloadFactory
                         ->setRefreshFlow($this->refreshFlow)


### PR DESCRIPTION
Hi , i saw a semi bug about "jwt.refresh" middleware that when i use it token refresh but decode method decode Previous Token !!
if i was wrong please forgive me because i am a beginner and please  give me solution.
thanks.    
