### PR TITLE
Add information for a setup with multiple guards

### DIFF
--- a/docs/auth-guard.md
+++ b/docs/auth-guard.md
@@ -2,6 +2,15 @@
 
 The following methods are available on the Auth guard instance.
 
+## Multiple Guards
+
+If the newly created 'api' guard is not set as a default guard or you have defined multiple guards to handle authentication,
+you should specify the guard when calling auth().
+
+```php
+  $token = auth('api')->attempt($credentials);
+```
+
 ### attempt()
 
 Attempt to authenticate a user via some credentials.

--- a/docs/auth-guard.md
+++ b/docs/auth-guard.md
@@ -2,7 +2,7 @@
 
 The following methods are available on the Auth guard instance.
 
-## Multiple Guards
+### Multiple Guards
 
 If the newly created 'api' guard is not set as a default guard or you have defined multiple guards to handle authentication,
 you should specify the guard when calling auth().


### PR DESCRIPTION
It is possible in laravel to specify multiple guards, the docs should reflect how to specify the guard type if the api guard is not set as the default.

auth('api')->login(); will trigger the custom jwt api guard for example.