### PR TITLE
Make testing easier with the JwtAuthentication trait

### DIFF
--- a/src/Claims/JwtAuthentication.php
+++ b/src/Claims/JwtAuthentication.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) Sean Tymon <tymon148@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tymon\JWTAuth\Claims;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+trait JwtAuthentication
+{
+    /**
+     * Overrides the default actingAs() method to set the user token when
+     * testing in Laravel.
+     *
+     * @param Authenticatable $user
+     * @param null|string $driver
+     * @return $this
+     */
+    public function actingAs(Authenticatable $user, $driver = null)
+    {
+        if (method_exists($this, 'withHeader')) {
+            $token = JWTAuth::fromUser($user);
+            $this->withHeader('Authorization', 'Bearer ' . $token);
+        }
+
+        return $this;
+    }
+}

--- a/src/Claims/JwtAuthentication.php
+++ b/src/Claims/JwtAuthentication.php
@@ -11,8 +11,8 @@
 
 namespace Tymon\JWTAuth\Claims;
 
-use Illuminate\Contracts\Auth\Authenticatable;
 use Tymon\JWTAuth\Facades\JWTAuth;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 trait JwtAuthentication
 {
@@ -22,13 +22,14 @@ trait JwtAuthentication
      *
      * @param Authenticatable $user
      * @param null|string $driver
+     *
      * @return $this
      */
     public function actingAs(Authenticatable $user, $driver = null)
     {
         if (method_exists($this, 'withHeader')) {
             $token = JWTAuth::fromUser($user);
-            $this->withHeader('Authorization', 'Bearer ' . $token);
+            $this->withHeader('Authorization', 'Bearer '.$token);
         }
 
         return $this;


### PR DESCRIPTION
> This PR is a simple solution for #1246.

### The Problem

By default, Laravel has the `actingAs()` method for tests, allowing you to log in a specific user before calling a route, for example.

When dealing with JWT the process is a bit different, because there's no session and the JWT must be sent in a request header.  😐

### The Solution

When using this package for the fist time, my first solution was overriding the `call()` method, adding a header to every call I was doing when testing. After digging some code I found an easier solution, just using a handful `withHeader()` method Laravel has.  🤔

This PR add a simple trait that overrides the `actingAs()` method when testing with Laravel, sending the `Bearer` header with the correct JWT in it. So, if you need to call some endpoint using JWT just use this trait and the `actingAs()` method:

```php
use JwtAuthentication;

public function test_the_header_is_set()
{
    $user = factory(User::class)->create();

    $this->actingAs($user)
        ->json('GET', '/foo')
        ->assertStatus(200);
}
```

And thanks for this amazing package! 👏💪🎉