### PR TITLE
Set the refreshed (new) token to the user

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -170,7 +170,11 @@ class JWTGuard implements Guard
      */
     public function refresh($forceForever = false, $resetClaims = false)
     {
-        return $this->requireToken()->refresh($forceForever, $resetClaims);
+        $token = $this->requireToken()->refresh($forceForever, $resetClaims);
+
+        $this->setToken($token)->setUser($this->user());
+
+        return $token;
     }
 
     /**


### PR DESCRIPTION
I stumbled upon this while trying `auth()->payload()` after refreshing a token, and getting `Tymon\JWTAuth\Exceptions\TokenBlacklistedException: The token has been blacklisted`. So I tried this; might not be the best solution, but it works.

Anyways. Every test still passes, besides:
```
Tymon\JWTAuth\Test\JWTGuardTest::it_should_refresh_the_token
Mockery\Exception\BadMethodCallException: Received Mockery_16_Tymon_JWTAuth_JWT::setToken(), but no expectations were specified

/path_to_the_repo/jwt-auth/src/JWTGuard.php:297
/path_to_the_repo/jwt-auth/src/JWTGuard.php:175
/path_to_the_repo/jwt-auth/tests/JWTGuardTest.php:313
```

Have a nice day!