### PR TITLE
[0.5] Laravel 5.8 Compatibility Fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "0.5-dev"
+            "dev-master": "0.5-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "mockery/mockery": "0.9.*",
         "illuminate/auth": "~5.0",
         "illuminate/database": "~5.0",
-        "illuminate/console" : "~5.0"
+        "illuminate/console" : "~5.0",
+        "illuminate/cache" : "~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "~5.0",
         "illuminate/http": "~5.0",
         "namshi/jose": "^5.0 || ^7.0",
-        "nesbot/carbon": "~1.0"
+        "nesbot/carbon": "~1.0 || ~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",

--- a/src/Middleware/BaseMiddleware.php
+++ b/src/Middleware/BaseMiddleware.php
@@ -57,7 +57,11 @@ abstract class BaseMiddleware
      */
     protected function respond($event, $error, $status, $payload = [])
     {
-        $response = $this->events->fire($event, $payload, true);
+        if (method_exists($this->events, 'dispatch')) {
+            $response = $this->events->dispatch($event, $payload, true);
+        } else {
+            $response = $this->events->fire($event, $payload, true);
+        }
 
         return $response ?: $this->response->json(['error' => $error], $status);
     }

--- a/src/Middleware/GetUserFromToken.php
+++ b/src/Middleware/GetUserFromToken.php
@@ -41,7 +41,11 @@ class GetUserFromToken extends BaseMiddleware
             return $this->respond('tymon.jwt.user_not_found', 'user_not_found', 404);
         }
 
-        $this->events->fire('tymon.jwt.valid', $user);
+        if (method_exists($this->events, 'dispatch')) {
+            $this->events->dispatch('tymon.jwt.valid', $user);
+        } else {
+            $this->events->fire('tymon.jwt.valid', $user);
+        }
 
         return $next($request);
     }

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -11,6 +11,8 @@
 
 namespace Tymon\JWTAuth;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Tymon\JWTAuth\Claims\Claim;
 use Tymon\JWTAuth\Exceptions\PayloadException;
 use Tymon\JWTAuth\Validators\PayloadValidator;
@@ -76,7 +78,7 @@ class Payload implements \ArrayAccess
                 return array_map([$this, 'get'], $claim);
             }
 
-            return array_get($this->toArray(), $claim, false);
+            return Arr::get($this->toArray(), $claim, false);
         }
 
         return $this->toArray();
@@ -122,7 +124,7 @@ class Payload implements \ArrayAccess
      */
     public function offsetGet($key)
     {
-        return array_get($this->toArray(), $key, []);
+        return Arr::get($this->toArray(), $key, []);
     }
 
     /**
@@ -160,7 +162,7 @@ class Payload implements \ArrayAccess
      */
     public function __call($method, $parameters)
     {
-        if (! method_exists($this, $method) && starts_with($method, 'get')) {
+        if (! method_exists($this, $method) && Str::startsWith($method, 'get')) {
             $class = sprintf('Tymon\\JWTAuth\\Claims\\%s', substr($method, 3));
 
             foreach ($this->claims as $claim) {

--- a/src/Providers/Storage/IlluminateCacheAdapter.php
+++ b/src/Providers/Storage/IlluminateCacheAdapter.php
@@ -81,7 +81,7 @@ class IlluminateCacheAdapter implements StorageInterface
     /**
      * Return the cache instance with tags attached.
      *
-     * @return \Illuminate\Cache\CacheManager
+     * @return \Illuminate\Cache\CacheManager|\Illuminate\Cache\TaggedCache
      */
     protected function cache()
     {

--- a/src/Providers/Storage/IlluminateCacheAdapter.php
+++ b/src/Providers/Storage/IlluminateCacheAdapter.php
@@ -43,7 +43,7 @@ class IlluminateCacheAdapter implements StorageInterface
      */
     public function add($key, $value, $minutes)
     {
-        $this->cache()->put($key, $value, $minutes);
+        $this->cache()->put($key, $value, $this->calculateTTL($minutes));
     }
 
     /**
@@ -90,5 +90,21 @@ class IlluminateCacheAdapter implements StorageInterface
         }
 
         return $this->cache->tags($this->tag);
+    }
+
+    /**
+     * Calculates the cache TTL, accounting for API differences introduced in Laravel 5.8.
+     *
+     * @param  int $ttl
+     * @return int Cache TTL in minutes or seconds depending on the version of `illuminate/cache` installed
+     */
+    protected function calculateTTL($ttl)
+    {
+        // There may be a more reliable check to use, but for now rely on the presence of classes introduced in 5.8 to decide which behavior to use
+        if (class_exists('Illuminate\Cache\DynamoDbLock')) {
+            $ttl = $ttl * 60;
+        }
+
+        return $ttl;
     }
 }

--- a/tests/Middleware/GetUserFromTokenTest.php
+++ b/tests/Middleware/GetUserFromTokenTest.php
@@ -41,7 +41,12 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
     {
         $this->auth->shouldReceive('getToken')->once()->andReturn(false);
 
-        $this->events->shouldReceive('fire')->once()->with('tymon.jwt.absent', [], true);
+        if (method_exists('Illuminate\Contracts\Events\Dispatcher', 'dispatch')) {
+            $this->events->shouldReceive('dispatch')->once()->with('tymon.jwt.absent', [], true);
+        } else {
+            $this->events->shouldReceive('fire')->once()->with('tymon.jwt.absent', [], true);
+        }
+
         $this->response->shouldReceive('json')->with(['error' => 'token_not_provided'], 400);
 
         $this->middleware->handle($this->request, function () {
@@ -56,7 +61,12 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
         $this->auth->shouldReceive('getToken')->once()->andReturn('foo');
         $this->auth->shouldReceive('authenticate')->once()->with('foo')->andThrow($exception);
 
-        $this->events->shouldReceive('fire')->once()->with('tymon.jwt.expired', [$exception], true);
+        if (method_exists('Illuminate\Contracts\Events\Dispatcher', 'dispatch')) {
+            $this->events->shouldReceive('dispatch')->once()->with('tymon.jwt.expired', [$exception], true);
+        } else {
+            $this->events->shouldReceive('fire')->once()->with('tymon.jwt.expired', [$exception], true);
+        }
+
         $this->response->shouldReceive('json')->with(['error' => 'token_expired'], 401);
 
         $this->middleware->handle($this->request, function () {
@@ -71,7 +81,12 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
         $this->auth->shouldReceive('getToken')->once()->andReturn('foo');
         $this->auth->shouldReceive('authenticate')->once()->with('foo')->andThrow($exception);
 
-        $this->events->shouldReceive('fire')->once()->with('tymon.jwt.invalid', [$exception], true);
+        if (method_exists('Illuminate\Contracts\Events\Dispatcher', 'dispatch')) {
+            $this->events->shouldReceive('dispatch')->once()->with('tymon.jwt.invalid', [$exception], true);
+        } else {
+            $this->events->shouldReceive('fire')->once()->with('tymon.jwt.invalid', [$exception], true);
+        }
+
         $this->response->shouldReceive('json')->with(['error' => 'token_invalid'], 400);
 
         $this->middleware->handle($this->request, function () {
@@ -84,7 +99,12 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
         $this->auth->shouldReceive('getToken')->once()->andReturn('foo');
         $this->auth->shouldReceive('authenticate')->once()->with('foo')->andReturn(false);
 
-        $this->events->shouldReceive('fire')->once()->with('tymon.jwt.user_not_found', [], true);
+        if (method_exists('Illuminate\Contracts\Events\Dispatcher', 'dispatch')) {
+            $this->events->shouldReceive('dispatch')->once()->with('tymon.jwt.user_not_found', [], true);
+        } else {
+            $this->events->shouldReceive('fire')->once()->with('tymon.jwt.user_not_found', [], true);
+        }
+
         $this->response->shouldReceive('json')->with(['error' => 'user_not_found'], 404);
 
         $this->middleware->handle($this->request, function () {
@@ -99,7 +119,12 @@ class GetUserFromTokenTest extends \PHPUnit_Framework_TestCase
         $this->auth->shouldReceive('getToken')->once()->andReturn('foo');
         $this->auth->shouldReceive('authenticate')->once()->with('foo')->andReturn($user);
 
-        $this->events->shouldReceive('fire')->once()->with('tymon.jwt.valid', $user);
+        if (method_exists('Illuminate\Contracts\Events\Dispatcher', 'dispatch')) {
+            $this->events->shouldReceive('dispatch')->once()->with('tymon.jwt.valid', $user);
+        } else {
+            $this->events->shouldReceive('fire')->once()->with('tymon.jwt.valid', $user);
+        }
+
         $this->response->shouldReceive('json')->never();
 
         $this->middleware->handle($this->request, function () {

--- a/tests/Providers/Storage/IlluminateCacheAdapterTest.php
+++ b/tests/Providers/Storage/IlluminateCacheAdapterTest.php
@@ -32,7 +32,9 @@ class IlluminateCacheAdapterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_add_the_item_to_storage()
     {
-        $this->cache->shouldReceive('tags->put')->with('foo', 'bar', 10);
+        $expectedTtl = class_exists('Illuminate\Cache\DynamoDbLock') ? 600 : 10;
+
+        $this->cache->shouldReceive('tags->put')->with('foo', 'bar', $expectedTtl);
 
         $this->storage->add('foo', 'bar', 10);
     }


### PR DESCRIPTION
If there's interest in a new 0.5 release with "proper" support for Laravel 5.8, then this branch should have all the needed changes (and if there's no interest, no big deal, I can use this on a project until migrating to 1.0).

Changes include:

- Using `Illuminate\Contracts\Events\Dispatcher::dispatch()` when available, falling back to the deprecated `Illuminate\Contracts\Events\Dispatcher::fire()`
- Avoiding use of the deprecated array and string helper functions in favor of the methods from `Illuminate\Support\Arr` and `Illuminate\Support\Str`
- Adapting `Tymon\JWTAuth\Providers\Storage\IlluminateCacheAdapter` to account for the changes in how the cache TTL is calculated
- Allowing Carbon 2 to be used (on a cursory check it looks like none of the [B/C breaks](https://carbon.nesbot.com/docs/#api-carbon-2) apply here)