### PR TITLE
Remove unsupported php versions from travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 build
 coverage.xml
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,32 +20,6 @@ matrix:
       dist: trusty
       env: LARAVEL='5.4.*' XDEBUG=1
       group: edge
-    - php: 5.5.9
-      env: LARAVEL='5.1.*'
-    - php: 5.5.9
-      env: LARAVEL='5.2.*'
-    - php: 5.5
-      env: LARAVEL='5.1.*'
-    - php: 5.5
-      env: LARAVEL='5.2.*'
-    - php: 5.6
-      env: LARAVEL='5.1.*'
-    - php: 5.6
-      env: LARAVEL='5.2.*'
-    - php: 5.6
-      env: LARAVEL='5.3.*'
-    - php: 5.6
-      env: LARAVEL='5.4.*'
-    - php: 7.0
-      env: LARAVEL='5.1.*'
-    - php: 7.0
-      env: LARAVEL='5.2.*'
-    - php: 7.0
-      env: LARAVEL='5.3.*'
-    - php: 7.0
-      env: LARAVEL='5.4.*'
-    - php: 7.0
-      env: LARAVEL='5.5.*'
     - php: 7.1
       env: LARAVEL='5.1.*'
     - php: 7.1

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -132,7 +132,7 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test */
     public function it_should_handle_datetinterval_claims()
     {
-        $testDateInterval = DateInterval::createFromDateString('PT1H');
+        $testDateInterval = new DateInterval('PT1H');
 
         $this->assertInstanceOf(DateInterval::class, $testDateInterval);
 


### PR DESCRIPTION
Removed PHP versions no longer supported in any way from travis testing
https://www.php.net/supported-versions.php

I was thinking potentially to update the composer.json to reflect that in requirements, but maybe there are still people for whatever reason running it unsupported. Let me know if that should be updated too.