### PR TITLE
Prevent validation when TTL is null

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -141,6 +141,9 @@ class Factory
         if ($this->claimFactory->getTTL() === null && $key = array_search('exp', $this->defaultClaims)) {
             unset($this->defaultClaims[$key]);
         }
+        if ($this->claimFactory->getTTL() === null && array_key_exists('exp', $this->customClaims)) {
+            unset($this->customClaims['exp']);
+        }
 
         // add the default claims
         foreach ($this->defaultClaims as $claim) {


### PR DESCRIPTION
When TTL is null, `exp` is removed from the default claims as expected. However, if the token was issued with an `exp` value, the payload causes `exp` to be added back to the claims to be validated against. 

Which leads to a situation where the TTL of null is ignored, with no way around it.

This pull request will remove `exp` fully from the claim stack come validation time if TTL is null.