### PR TITLE
Dont alter the default claims

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tymon/jwt-auth",
+    "name": "jezzdk/jwt-auth",
     "description": "JSON Web Token Authentication for Laravel and Lumen",
     "keywords": [
         "auth",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -13,10 +13,10 @@ namespace Tymon\JWTAuth;
 
 use Tymon\JWTAuth\Claims\Claim;
 use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Support\RefreshFlow;
-use Tymon\JWTAuth\Support\CustomClaims;
-use Tymon\JWTAuth\Validators\PayloadValidator;
 use Tymon\JWTAuth\Claims\Factory as ClaimFactory;
+use Tymon\JWTAuth\Support\CustomClaims;
+use Tymon\JWTAuth\Support\RefreshFlow;
+use Tymon\JWTAuth\Validators\PayloadValidator;
 
 class Factory
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -139,6 +139,8 @@ class Factory
     {
         $defaultClaims = $this->defaultClaims;
 
+        $this->emptyClaims();
+
         // remove the exp claim if it exists and the ttl is null
         if ($this->claimFactory->getTTL() === null && $key = array_search('exp', $defaultClaims)) {
             unset($defaultClaims[$key]);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -137,13 +137,15 @@ class Factory
      */
     protected function buildClaims()
     {
+        $defaultClaims = $this->defaultClaims;
+
         // remove the exp claim if it exists and the ttl is null
-        if ($this->claimFactory->getTTL() === null && $key = array_search('exp', $this->defaultClaims)) {
-            unset($this->defaultClaims[$key]);
+        if ($this->claimFactory->getTTL() === null && $key = array_search('exp', $defaultClaims)) {
+            unset($defaultClaims[$key]);
         }
 
         // add the default claims
-        foreach ($this->defaultClaims as $claim) {
+        foreach ($defaultClaims as $claim) {
             $this->addClaim($claim, $this->claimFactory->make($claim));
         }
 


### PR DESCRIPTION
This will allow stuff like auth()->setTTL(1440) to actually work when having NULL as the default TTL.

I needed this because the same code is run when calling authenticated routes (through auth()->check()). Having the TTL set to NULL in the config would remove the exp claim from default claims, in which case the TTL could no longer be overwritten later in the code.