### PR TITLE
Fixed issue with AuthHeaders parser stripping trailing hyphens from tokens

### DIFF
--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -54,9 +54,9 @@ class AuthHeaders implements ParserContract
         $header = $request->headers->get($this->header) ?: $this->fromAltHeaders($request);
 
         if ($header) {
-            $start = strlen($this->prefix) + 1; // +1 to include the space separator
+            $start = strlen($this->prefix);
 
-            return substr($header, $start);
+            return trim(substr($header, $start));
         }
     }
 

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -53,8 +53,10 @@ class AuthHeaders implements ParserContract
     {
         $header = $request->headers->get($this->header) ?: $this->fromAltHeaders($request);
 
-        if ($header && preg_match('/'.$this->prefix.'\s*(\S+)\b/i', $header, $matches)) {
-            return $matches[1];
+        if ($header) {
+            $start = strlen($this->prefix) + 1; // +1 to include the space separator
+
+            return substr($header, $start);
         }
     }
 

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -108,6 +108,25 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
+    public function it_should_not_strip_trailing_hyphens_from_the_authorization_header()
+    {
+        $request = Request::create('foo', 'POST');
+        $request->headers->set('Authorization', 'Bearer foobar--');
+
+        $parser = new Parser($request);
+
+        $parser->setChain([
+            new QueryString,
+            new InputSource,
+            new AuthHeaders,
+            new RouteParams,
+        ]);
+
+        $this->assertSame($parser->parseToken(), 'foobar--');
+        $this->assertTrue($parser->hasToken());
+    }
+
+    /** @test */
     public function it_should_return_the_token_from_query_string()
     {
         $request = Request::create('foo', 'GET', ['token' => 'foobar']);

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -126,6 +126,43 @@ class ParserTest extends AbstractTestCase
         $this->assertTrue($parser->hasToken());
     }
 
+    /**
+     * @test
+     * @dataProvider whitespaceProvider
+     */
+    public function it_should_handle_excess_whitespace_from_the_authorization_header($whitespace)
+    {
+        $request = Request::create('foo', 'POST');
+        $request->headers->set('Authorization', "Bearer{$whitespace}foobar{$whitespace}");
+
+        $parser = new Parser($request);
+
+        $parser->setChain([
+            new QueryString,
+            new InputSource,
+            new AuthHeaders,
+            new RouteParams,
+        ]);
+
+        $this->assertSame($parser->parseToken(), 'foobar');
+        $this->assertTrue($parser->hasToken());
+    }
+
+    public function whitespaceProvider()
+    {
+        return [
+            'space' => [' '],
+            'multiple spaces' => ['    '],
+            'tab' => ["\t"],
+            'multiple tabs' => ["\t\t\t"],
+            'new line' => ["\n"],
+            'multiple new lines' => ["\n\n\n"],
+            'carriage return' => ["\r"],
+            'carriage returns' => ["\r\r\r"],
+            'mixture of whitespace' => ["\t \n \r \t \n"],
+        ];
+    }
+
     /** @test */
     public function it_should_return_the_token_from_query_string()
     {


### PR DESCRIPTION
We ran into an intermittent issue when using this library where sometimes a token (that appeared to be valid as far as we could tell) would be rendered invalid or unparseable by the library.

After some debugging, I determined it was from the AuthHeaders parser unintentionally stripping trailing hyphens from a header (eg. `Bearer foobar--` would become the token `foobar`).

On our end I added a bandaid that generates tokens without trailing hyphens, but this PR should serve to fix the issue entirely.

Note that the parse method went from using regex to simply grabbing everything in the string after the prefix (and the space separator).