### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -83,8 +83,8 @@ First let's add some routes in `routes/api.php` as follows:
 ```php
 Route::group([
 
-    'middleware' => 'api',
-    'prefix' => 'auth'
+    'middleware' => 'auth',
+    'prefix' => 'api'
 
 ], function ($router) {
 


### PR DESCRIPTION
Correct typo found in quick-start.md:86-87

    'middleware' => 'api',
    'prefix' => 'auth'
to
    'middleware' => 'auth',
    'prefix' => 'api'