### PR TITLE
CookiesParser - do not unserialize by default when decrypting

### DIFF
--- a/src/Http/Parser/Cookies.php
+++ b/src/Http/Parser/Cookies.php
@@ -41,7 +41,7 @@ class Cookies implements ParserContract
     public function parse(Request $request)
     {
         if ($this->decrypt && $request->hasCookie($this->key)) {
-            return Crypt::decrypt($request->cookie($this->key));
+            return Crypt::decryptString($request->cookie($this->key));
         }
 
         return $request->cookie($this->key);


### PR DESCRIPTION
Since Laravel 5.5.42 and 5.6.30 encrypted cookies are no longer serialized. Since Laravel 5.5 LTS support ends in August and 5.6 EOL reached over a year ago, I'd suggest that this package would opt to decrypt cookies without serialization as a default.