### PR TITLE
styleci: remove is_null fixer

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,6 @@
 preset: laravel
 
 enabled:
-  - is_null
   - no_useless_else
   - phpdoc_order
   - phpdoc_separation


### PR DESCRIPTION
Fixes this error from StyleCI
> The risky 'is_null' fixer cannot be enabled because risky mode is not enabled.