### PR TITLE
Renew iat on refresh token

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -179,8 +179,7 @@ class Manager
             $this->customClaims,
             $persistentClaims,
             [
-                'sub' => $payload['sub'],
-                'iat' => $payload['iat'],
+                'sub' => $payload['sub']
             ]
         );
     }


### PR DESCRIPTION
Hello everyone,

First of all I want to say that this is my very first contribution so please bear with me.

The purpose of this pull request is to address a rather important concern about my project. I want the users of my project to be able to refresh their token ad infinitum but this is not possible because every time they get a new token the `iat` field doesn't update so they end up exceeding the `refresh_ttl`.

My contribution is quite simple, I just removed IAT from the `persistentClaims` on refresh token. 

Don't hesitate to tell me if my solution is not optimal.