### PR TITLE
Add more config for parsers

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -239,21 +239,80 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cookies encryption
+    | Configuration for Parsers
     |--------------------------------------------------------------------------
     |
-    | By default Laravel encrypt cookies for security reason.
-    | If you decide to not decrypt cookies, you will have to configure Laravel
-    | to not encrypt your cookie token by adding its name into the $except
-    | array available in the middleware "EncryptCookies" provided by Laravel.
-    | see https://laravel.com/docs/master/responses#cookies-and-encryption
-    | for details.
-    |
-    | Set it to true if you want to decrypt cookies.
+    | Specify the configuration of various parsers used throughout the package.
     |
     */
 
-    'decrypt_cookies' => false,
+    'parsers' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Auth header
+        |--------------------------------------------------------------------------
+        |
+        | Parse token from specific header
+        |
+        */
+
+        'auth_header' => [
+
+            /*
+            |--------------------------------------------------------------------------
+            | HTTP Authorization Header
+            |--------------------------------------------------------------------------
+            |
+            | Name of header has token value
+            |
+            */
+
+            'header' => 'authorization',
+
+            /*
+            |--------------------------------------------------------------------------
+            | Prefix
+            |--------------------------------------------------------------------------
+            |
+            | Prefix text right before token
+            |
+            */
+
+            'prefix' => 'bearer',
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Cookie
+        |--------------------------------------------------------------------------
+        |
+        | Parse token from cookie
+        |
+        */
+
+        'cookie' => [
+
+            /*
+            |--------------------------------------------------------------------------
+            | Cookies encryption
+            |--------------------------------------------------------------------------
+            |
+            | By default Laravel encrypt cookies for security reason.
+            | If you decide to not decrypt cookies, you will have to configure Laravel
+            | to not encrypt your cookie token by adding its name into the $except
+            | array available in the middleware "EncryptCookies" provided by Laravel.
+            | see https://laravel.com/docs/master/responses#cookies-and-encryption
+            | for details.
+            |
+            | Set it to true if you want to decrypt cookies.
+            |
+            */
+
+            'decrypt' => false,
+        ],
+
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -21,14 +21,20 @@ class AuthHeaders implements ParserContract
      *
      * @var string
      */
-    protected $header = 'authorization';
+    protected $header;
 
     /**
      * The header prefix.
      *
      * @var string
      */
-    protected $prefix = 'bearer';
+    protected $prefix;
+
+    public function __construct($header = 'authorization', $prefix = 'bearer')
+    {
+        $this->header = $header;
+        $this->prefix = $prefix;
+    }
 
     /**
      * Attempt to parse the token from some other possible headers.

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -232,11 +232,11 @@ abstract class AbstractServiceProvider extends ServiceProvider
             $parser = new Parser(
                 $app['request'],
                 [
-                    new AuthHeaders,
+                    new AuthHeaders($this->config('parsers.auth_header.header'), $this->config('parsers.auth_header.prefix')),
                     new QueryString,
                     new InputSource,
                     new RouteParams,
-                    new Cookies($this->config('decrypt_cookies')),
+                    new Cookies($this->config('parsers.cookie.decrypt')),
                 ]
             );
 

--- a/src/Providers/LumenServiceProvider.php
+++ b/src/Providers/LumenServiceProvider.php
@@ -33,7 +33,7 @@ class LumenServiceProvider extends AbstractServiceProvider
         $this->extendAuthGuard();
 
         $this->app['tymon.jwt.parser']->setChain([
-            new AuthHeaders,
+            new AuthHeaders($this->config('parsers.auth_header.header'), $this->config('parsers.auth_header.prefix')),
             new QueryString,
             new InputSource,
             new LumenRouteParams,

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -46,6 +46,25 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
+    public function it_should_return_the_token_from_the_custom_header_and_custom_prefix()
+    {
+        $request = Request::create('foo', 'POST');
+        $request->headers->set('X-Authorization', 'Token foobar');
+
+        $parser = new Parser($request);
+
+        $parser->setChain([
+            new QueryString,
+            new InputSource,
+            new AuthHeaders('x-authorization', 'token'),
+            new RouteParams,
+        ]);
+
+        $this->assertSame($parser->parseToken(), 'foobar');
+        $this->assertTrue($parser->hasToken());
+    }
+
+    /** @test */
     public function it_should_return_the_token_from_the_prefixed_authentication_header()
     {
         $request = Request::create('foo', 'POST');


### PR DESCRIPTION
Hi,
This PR provide a convenient way for user to customize parameters for Auth Header parser (header + prefix).
In addition, I did group all configurations for parsers under main group 'parsers'.

All testcases are passed.