### PR TITLE
docs: add laravel 8 proper install script

### DIFF
--- a/docs/laravel-installation.md
+++ b/docs/laravel-installation.md
@@ -2,6 +2,12 @@
 
 Run the following command to pull in the latest version:
 
+For laravel 8 or above
+```bash
+composer require tymon/jwt-auth:^1.0.2
+```
+
+Otherwise
 ```bash
 composer require tymon/jwt-auth
 ```


### PR DESCRIPTION
If users install env is laravel 8, with the original instruction, it doesnt work as follows

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires tymon/jwt-auth ^0.5.12 -> satisfiable by tymon/jwt-auth[0.5.12].
    - tymon/jwt-auth 0.5.12 requires illuminate/support ~5.0 -> found illuminate/support[v5.0.0, ..., 5.8.x-dev] but these were not loaded, likely because it conflicts with another require.

```

by specifying min version, it can be fixed.