### PR TITLE
fix: should throw TokenInvalidException if received an invalid encrypted cookie token.

### DIFF
--- a/src/Http/Parser/Cookies.php
+++ b/src/Http/Parser/Cookies.php
@@ -11,9 +11,11 @@
 
 namespace Tymon\JWTAuth\Http\Parser;
 
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
 use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 
 class Cookies implements ParserContract
 {
@@ -41,7 +43,11 @@ class Cookies implements ParserContract
     public function parse(Request $request)
     {
         if ($this->decrypt && $request->hasCookie($this->key)) {
-            return Crypt::decrypt($request->cookie($this->key));
+            try {
+                return Crypt::decrypt($request->cookie($this->key));
+            } catch (DecryptException $ex) {
+                throw new TokenInvalidException('Token has not decrypted successfully.');
+            }
         }
 
         return $request->cookie($this->key);

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -11,11 +11,13 @@
 
 namespace Tymon\JWTAuth\Test\Http;
 
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Crypt;
 use Mockery;
 use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 use Tymon\JWTAuth\Http\Parser\AuthHeaders;
 use Tymon\JWTAuth\Http\Parser\Cookies;
 use Tymon\JWTAuth\Http\Parser\InputSource;
@@ -312,6 +314,29 @@ class ParserTest extends AbstractTestCase
 
         $this->assertSame($parser->parseToken(), 'foobar');
         $this->assertTrue($parser->hasToken());
+    }
+
+    /** @test */
+    public function it_should_throw_token_invalid_exception_from_a_invalid_encrypted_cookie()
+    {
+        $request = Request::create('foo', 'POST', [], ['token' => 'foobar']);
+
+        $parser = new Parser($request);
+        $parser->setChain([
+            new AuthHeaders,
+            new QueryString,
+            new InputSource,
+            new RouteParams,
+            new Cookies(true),
+        ]);
+
+        Crypt::shouldReceive('decrypt')
+            ->with('foobar')
+            ->andThrow(new DecryptException());
+
+        $this->expectException(TokenInvalidException::class);
+
+        $parser->parseToken();
     }
 
     /** @test */


### PR DESCRIPTION
Currently if you had invalid encrypted token in cookie, and will throw DecryptException directly without handling.