### PR TITLE
Without realpath this will work

### DIFF
--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -21,7 +21,7 @@ class LaravelServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $path = realpath(__DIR__.'/../../config/config.php');
+        $path = __DIR__.'/../../config/config.php';
 
         $this->publishes([$path => config_path('jwt.php')], 'config');
         $this->mergeConfigFrom($path, 'jwt');


### PR DESCRIPTION
Currently working on a project (with Laravel) that requires to be bundled in a Phar. The realpath is [not working within the Phar setup](https://www.php.net/manual/en/function.realpath.php#refsect1-function.realpath-returnvalues).
 
This change will allow to work properly and won't break for Laravel projects (it is only applying for Laravel projects).