### PR TITLE
PHP8 & lcobucci/jwt 4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/contracts": "^5.2|^6|^7|^8",
         "illuminate/http": "^5.2|^6|^7|^8",
         "illuminate/support": "^5.2|^6|^7|^8",
-        "lcobucci/jwt": "<3.4",
+        "lcobucci/jwt": "~3.4",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^1.0|^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/contracts": "^5.2|^6|^7|^8",
         "illuminate/http": "^5.2|^6|^7|^8",
         "illuminate/support": "^5.2|^6|^7|^8",
-        "lcobucci/jwt": "~3.4",
+        "lcobucci/jwt": "^3.4|^4.0",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^1.0|^2.0"
     },

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -167,8 +167,6 @@ abstract class AbstractServiceProvider extends ServiceProvider
     {
         $this->app->singleton('tymon.jwt.provider.jwt.lcobucci', function ($app) {
             return new Lcobucci(
-                new JWTBuilder(),
-                new JWTParser(),
                 $this->config('secret'),
                 $this->config('algo'),
                 $this->config('keys')

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -12,8 +12,6 @@
 namespace Tymon\JWTAuth\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Lcobucci\JWT\Builder as JWTBuilder;
-use Lcobucci\JWT\Parser as JWTParser;
 use Namshi\JOSE\JWS;
 use Tymon\JWTAuth\Blacklist;
 use Tymon\JWTAuth\Claims\Factory as ClaimFactory;

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -123,7 +123,7 @@ class Lcobucci extends Provider implements JWT
      */
     public function encode(array $payload)
     {
-	    $this->builder = null;
+        $this->builder = null;
         try {
             foreach ($payload as $key => $value) {
                 $this->addClaim( $key, $value );
@@ -142,12 +142,12 @@ class Lcobucci extends Provider implements JWT
      */
     protected function addClaim($key, $value)
     {
-    	if (!isset($this->builder)) {
-		    $this->builder = $this->config->builder();
-	    }
+        if (!isset($this->builder)) {
+            $this->builder = $this->config->builder();
+        }
         switch ($key) {
             case RegisteredClaims::ID:
-	            $this->builder->identifiedBy($value);
+                $this->builder->identifiedBy($value);
                 break;
             case RegisteredClaims::EXPIRATION_TIME:
                     $this->builder->expiresAt(\DateTimeImmutable::createFromFormat('U', $value));
@@ -194,7 +194,13 @@ class Lcobucci extends Provider implements JWT
         }
 
         return (new Collection($jwt->claims()->all()))->map(function ($claim) {
-            return is_object($claim) ? $claim->getValue() : $claim;
+            if ( is_a($claim, \DateTimeImmutable::class)) {
+                return $claim->getTimestamp();
+            }
+            if ( is_object($claim) && method_exists( $claim, 'getValue') ) {
+                return $claim->getValue();
+            }
+            return $claim;
         })->toArray();
     }
 

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -27,6 +27,7 @@ use Lcobucci\JWT\Signer\Rsa\Sha256 as RS256;
 use Lcobucci\JWT\Signer\Rsa\Sha384 as RS384;
 use Lcobucci\JWT\Signer\Rsa\Sha512 as RS512;
 use Lcobucci\JWT\Token\RegisteredClaims;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use ReflectionClass;
 use Tymon\JWTAuth\Contracts\Providers\JWT;
 use Tymon\JWTAuth\Exceptions\JWTException;
@@ -73,6 +74,11 @@ class Lcobucci extends Provider implements JWT
         }
         else {
             $this->config = Configuration::forSymmetricSigner($this->signer, InMemory::plainText( $this->getSecret() ) );
+        }
+        if ( !count($this->config->validationConstraints()) ) {
+            $this->config->setValidationConstraints(
+                new SignedWith($this->signer, $this->getVerificationKey()),
+            );
         }
     }
     
@@ -217,7 +223,7 @@ class Lcobucci extends Provider implements JWT
     {
         return $this->isAsymmetric() ?
             InMemory::plainText($this->getPrivateKey(), $this->getPassphrase() ?? '') :
-            $this->getSecret();
+            InMemory::plainText($this->getSecret());
     }
 
     /**
@@ -227,6 +233,6 @@ class Lcobucci extends Provider implements JWT
     {
         return $this->isAsymmetric() ?
             InMemory::plainText($this->getPublicKey()) :
-            $this->getSecret();
+            InMemory::plainText($this->getSecret());
     }
 }

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -14,8 +14,15 @@ namespace Tymon\JWTAuth\Test\Providers\JWT;
 use Exception;
 use InvalidArgumentException;
 use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Rsa\Sha256 as RS256;
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\DataSet;
+use Lcobucci\JWT\Validation\Constraint;
+use Lcobucci\JWT\Validation\Validator;
 use Mockery;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
@@ -25,6 +32,13 @@ use Tymon\JWTAuth\Test\AbstractTestCase;
 class LcobucciTest extends AbstractTestCase
 {
     /**
+     * Mocks {@see Configuration}.
+     *
+     * @var \Mockery\MockInterface
+     */
+    protected $config;
+    
+    /**
      * @var \Mockery\MockInterface
      */
     protected $parser;
@@ -33,33 +47,41 @@ class LcobucciTest extends AbstractTestCase
      * @var \Mockery\MockInterface
      */
     protected $builder;
-
+    
     /**
-     * @var \Tymon\JWTAuth\Providers\JWT\Namshi
+     * @var \Mockery\MockInterface
      */
-    protected $provider;
+    protected $validator;
 
     public function setUp(): void
     {
         parent::setUp();
-
-        $this->builder = Mockery::mock(Builder::class);
-        $this->parser = Mockery::mock(Parser::class);
+    
+        $this->builder   = Mockery::mock( Builder::class );
+        $this->parser    = Mockery::mock( Parser::class );
     }
 
     /** @test */
     public function it_should_return_the_token_when_passing_a_valid_payload_to_encode()
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
+    
+        $dataSet = new DataSet($payload, 'payload');
 
-        $this->builder->shouldReceive('unsign')->once()->andReturnSelf();
-        $this->builder->shouldReceive('set')->times(count($payload));
-        $this->builder->shouldReceive('sign')->once()->with(Mockery::any(), 'secret');
-        $this->builder->shouldReceive('getToken')->once()->andReturn('foo.bar.baz');
+        $this->builder->shouldReceive('relatedTo')->once()->andReturnSelf(); // sub
+        $this->builder->shouldReceive('expiresAt')->once()->andReturnSelf(); // exp
+        $this->builder->shouldReceive('issuedAt')->once()->andReturnSelf();  // iat
+        $this->builder->shouldReceive('issuedBy')->once()->andReturnSelf();  // iss
+        $this->builder
+            ->shouldReceive('getToken')
+            ->once()
+            ->with(\Mockery::type(Signer::class), \Mockery::type(Key::class))
+            ->andReturn(new Token\Plain(new DataSet([], 'header'), $dataSet, (new Token\Signature('', 'signature'))));
 
+        /** @var Token $token */
         $token = $this->getProvider('secret', 'HS256')->encode($payload);
 
-        $this->assertSame('foo.bar.baz', $token);
+        $this->assertSame('header.payload.signature', $token );
     }
 
     /** @test */
@@ -69,10 +91,16 @@ class LcobucciTest extends AbstractTestCase
         $this->expectExceptionMessage('Could not create token:');
 
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
-
-        $this->builder->shouldReceive('unsign')->once()->andReturnSelf();
-        $this->builder->shouldReceive('set')->times(count($payload));
-        $this->builder->shouldReceive('sign')->once()->with(Mockery::any(), 'secret')->andThrow(new Exception);
+    
+        $this->builder->shouldReceive('relatedTo')->once()->andReturnSelf(); // sub
+        $this->builder->shouldReceive('expiresAt')->once()->andReturnSelf(); // exp
+        $this->builder->shouldReceive('issuedAt')->once()->andReturnSelf();  // iat
+        $this->builder->shouldReceive('issuedBy')->once()->andReturnSelf();  // iss
+        $this->builder
+            ->shouldReceive('getToken')
+            ->once()
+            ->with(\Mockery::type(Signer::class), \Mockery::type(Key::class))
+            ->andThrow(new Exception);
 
         $this->getProvider('secret', 'HS256')->encode($payload);
     }
@@ -81,25 +109,37 @@ class LcobucciTest extends AbstractTestCase
     public function it_should_return_the_payload_when_passing_a_valid_token_to_decode()
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
+        
+        $token = Mockery::mock(Token::class);
+        $dataSet = Mockery::mock(new DataSet($payload, 'payload'));
+        
+        $provider = $this->getProvider('secret', 'HS256');
+        
+        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andReturn($token);
+        $this->validator->shouldReceive('validate')->once()->with($token, Mockery::any())->andReturnTrue();
+        $token->shouldReceive('claims')->once()->andReturn($dataSet);
+        $dataSet->shouldReceive( 'all')->once()->andReturn($payload);
 
-        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andReturn(Mockery::self());
-        $this->parser->shouldReceive('verify')->once()->with(Mockery::any(), 'secret')->andReturn(true);
-        $this->parser->shouldReceive('getClaims')->once()->andReturn($payload);
-
-        $this->assertSame($payload, $this->getProvider('secret', 'HS256')->decode('foo.bar.baz'));
+        $this->assertSame($payload, $provider->decode('foo.bar.baz'));
     }
 
     /** @test */
     public function it_should_throw_a_token_invalid_exception_when_the_token_could_not_be_decoded_due_to_a_bad_signature()
     {
+        $token = Mockery::mock(Token::class);
+        $dataSet = Mockery::mock(new DataSet(['pay','load'], 'payload'));
+        
+        $provider = $this->getProvider('secret', 'HS256');
+        
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Token Signature could not be verified.');
-
-        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andReturn(Mockery::self());
-        $this->parser->shouldReceive('verify')->once()->with(Mockery::any(), 'secret')->andReturn(false);
-        $this->parser->shouldReceive('getClaims')->never();
-
-        $this->getProvider('secret', 'HS256')->decode('foo.bar.baz');
+    
+        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andReturn($token);
+        $this->validator->shouldReceive('validate')->once()->with($token, Mockery::any())->andReturnFalse();
+        $token->shouldReceive('claims')->never();
+        $dataSet->shouldReceive( 'all')->never();
+    
+        $provider->decode('foo.bar.baz');
     }
 
     /** @test */
@@ -118,22 +158,32 @@ class LcobucciTest extends AbstractTestCase
     /** @test */
     public function it_should_generate_a_token_when_using_an_rsa_algorithm()
     {
+        $dummyPrivateKey = $this->getDummyPrivateKey();
+        $dummyPublicKey  = $this->getDummyPublicKey();
+        
         $provider = $this->getProvider(
             'does_not_matter',
             'RS256',
-            ['private' => $this->getDummyPrivateKey(), 'public' => $this->getDummyPublicKey()]
+            ['private' => $dummyPrivateKey, 'public' => $dummyPublicKey]
         );
 
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
-
-        $this->builder->shouldReceive('unsign')->once()->andReturnSelf();
-        $this->builder->shouldReceive('set')->times(count($payload));
-        $this->builder->shouldReceive('sign')->once()->with(Mockery::any(), Mockery::type(Key::class));
-        $this->builder->shouldReceive('getToken')->once()->andReturn('foo.bar.baz');
+    
+        $dataSet = new DataSet($payload, 'payload');
+    
+        $this->builder->shouldReceive('relatedTo')->once()->andReturnSelf(); // sub
+        $this->builder->shouldReceive('expiresAt')->once()->andReturnSelf(); // exp
+        $this->builder->shouldReceive('issuedAt')->once()->andReturnSelf();  // iat
+        $this->builder->shouldReceive('issuedBy')->once()->andReturnSelf();  // iss
+        $this->builder
+            ->shouldReceive('getToken')
+            ->once()
+            ->with(Mockery::type(RS256::class), Mockery::type(Key::class))
+            ->andReturn(new Token\Plain(new DataSet([], 'header'), $dataSet, (new Token\Signature('', 'signature'))));
 
         $token = $provider->encode($payload);
 
-        $this->assertSame('foo.bar.baz', $token);
+        $this->assertSame('header.payload.signature', $token);
     }
 
     /** @test */
@@ -174,7 +224,22 @@ class LcobucciTest extends AbstractTestCase
 
     public function getProvider($secret, $algo, array $keys = [])
     {
-        return new Lcobucci($this->builder, $this->parser, $secret, $algo, $keys);
+        $provider = new Lcobucci($secret, $algo, $keys);
+        
+        $this->validator = Mockery::mock( \Lcobucci\JWT\Validator::class );
+        $this->config = Mockery::mock($provider->getConfig());
+        
+        $provider = new Lcobucci($secret, $algo, $keys, $this->config);
+        
+        $this->config->shouldReceive('builder')->andReturn($this->builder);
+        $this->config->shouldReceive('parser')->andReturn($this->parser);
+        $this->config->shouldReceive('validator')->andReturn($this->validator);
+        
+        $constraint = Mockery::mock(Constraint::class);
+        $constraint->shouldReceive('assert')->andReturn();
+        $this->config->shouldReceive('validationConstraints')->andReturn([$constraint]);
+        
+        return $provider;
     }
 
     public function getDummyPrivateKey()


### PR DESCRIPTION
This PR addresses #2088, #2082, #2103 and probably others. It probably supersedes #2073 which does not include all required changes to update `lcobucci/jwt` to v4.x. Also relates to topics mentioned under #2059.

Existing tests are updated and pass, and I've also tried some basic use-cases. You can see 3 fixes in the gitlog. The "funny" thing is that those serious issues were not indicated by any automated tests. Probably it would be best to make some tests that check if the tokens are generated with the right content and validated properly, instead of only checking if mocked methods are being called. That being said, I cannot spend more time on this, so I'll leave it up to others.

Please note I'm not a security expert, so review before using this for anything serious!