### PR TITLE
doc: correct the method registerNamshiProvider PHPdoc description

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -142,7 +142,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the bindings for the Lcobucci JWT provider.
+     * Register the bindings for the Namshi JWT provider.
      *
      * @return void
      */


### PR DESCRIPTION
Thanks for putting this useful Library together.

This PR is to correct the PHPDoc description for the `AbstractServiceProvider::registerNamshiProvider` method.