### PR TITLE
Created new configurations to optional TokenBlacklistedException

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -298,7 +298,17 @@ return [
         */
 
         'storage' => Tymon\JWTAuth\Providers\Storage\Illuminate::class,
+        
+        /*
+        |--------------------------------------------------------------------------
+        | Show blacklisted token option
+        |--------------------------------------------------------------------------
+        |
+        | Specify if you want to show black listed token exception on the laravel logs.
+        |
+        */
 
+        'show_black_list_exception' => env('JWT_SHOW_BLACKLIST_EXCEPTION', true),
     ],
 
 ];

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -56,6 +56,8 @@ class Manager
      */
     protected $persistentClaims = [];
 
+    protected $showBlackListException = true;
+
     /**
      * Constructor.
      *
@@ -106,7 +108,14 @@ class Manager
                         ->make();
 
         if ($checkBlacklist && $this->blacklistEnabled && $this->blacklist->has($payload)) {
-            throw new TokenBlacklistedException('The token has been blacklisted');
+            if (
+                $checkBlacklist &&
+                $this->blacklistEnabled &&
+                $this->blacklist->has($payload) &&
+                $this->gettBlackListExceptionEnabled()
+            ) {
+                throw new TokenBlacklistedException('The token has been blacklisted');
+            }
         }
 
         return $payload;
@@ -227,6 +236,31 @@ class Manager
         $this->blacklistEnabled = $enabled;
 
         return $this;
+    }
+
+    /**
+     * Configuration to set up if show the TokenBlacklistedException
+     * can be throwable or not.
+     *
+     * @param bool $showBlackListException
+     *
+     * @removed this
+     */
+    public function setBlackListExceptionEnabled($showBlackListException = true)
+    {
+        $this->showBlackListException = $showBlackListException;
+
+        return $this;
+    }
+
+    /**
+     * Get if the blacklist instance is enabled.
+     *
+     * @return bool
+     */
+    public function gettBlackListExceptionEnabled()
+    {
+        return $this->showBlackListException;
     }
 
     /**

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -215,7 +215,9 @@ abstract class AbstractServiceProvider extends ServiceProvider
             );
 
             return $instance->setBlacklistEnabled((bool) $this->config('blacklist_enabled'))
-                            ->setPersistentClaims($this->config('persistent_claims'));
+                ->setPersistentClaims($this->config('persistent_claims'));
+                ->setPersistentClaims($this->config('persistent_claims'))
+                ->setBlackListExceptionEnabled((bool) $this->config('show_black_list_exception', true));
         });
     }
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -276,4 +276,28 @@ class ManagerTest extends AbstractTestCase
     {
         $this->assertInstanceOf(Blacklist::class, $this->manager->getBlacklist());
     }
+
+     /** @test */
+     public function test_if_show_blacklisted_exception_configuration_is_enabled()
+     {
+         $this->manager->setBlackListExceptionEnabled(true);
+ 
+         $this->assertIsBool($this->manager->gettBlackListExceptionEnabled());
+     }
+ 
+     /** @test */
+     public function test_if_black_listed_exception_is_set_to_true()
+     {
+         $this->manager->setBlackListExceptionEnabled(true);
+ 
+         $this->assertTrue($this->manager->gettBlackListExceptionEnabled());
+     }
+ 
+     /** @test */
+     public function test_if_black_listed_exception_is_set_to_false()
+     {
+         $this->manager->setBlackListExceptionEnabled(false);
+ 
+         $this->assertFalse($this->manager->gettBlackListExceptionEnabled());
+     }
 }


### PR DESCRIPTION
As been related on #2002, #457, #988, #1573, #983 (this is still open by the way), and in Laravel's application the TokenBlacklistedException shows just because we log out.

Even setting up the grace period to 30 still having the same issue, so I believe the TokenBlacklistedException should be optional since if someone is logged out, forced to log out, or even blacklisted for us (or by application) the exception most of the cases doesn't seem quite relevant to us to see.


This pull request it's a proposal to make this exception just be throwable by option.