### PR TITLE
Fix for issue #2143

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -78,7 +78,7 @@ class Factory
      *
      * @return \Tymon\JWTAuth\Payload
      */
-    public function make($resetClaims = false)
+    public function make($resetClaims = true)
     {
         if ($resetClaims) {
             $this->emptyClaims();


### PR DESCRIPTION
This is one possible fix for issue #2143. Another possible fix is clearing the claims before a JWT is parsed by calling `\Tymon\JWTAuth\Facades\JWTFactory::emptyClaims();` in `Tymon\JWTAuth\Http\Middleware\BaseMiddleware`, however, that class is marked as deprecated.

