### PR TITLE
lumen and Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,18 +24,18 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/auth": "^5.2|^6|^7|^8",
-        "illuminate/contracts": "^5.2|^6|^7|^8",
-        "illuminate/http": "^5.2|^6|^7|^8",
-        "illuminate/support": "^5.2|^6|^7|^8",
+        "illuminate/auth": "^5.2|^6|^7|^8|^9",
+        "illuminate/contracts": "^5.2|^6|^7|^8|^9",
+        "illuminate/http": "^5.2|^6|^7|^8|^9",
+        "illuminate/support": "^5.2|^6|^7|^8|^9",
         "lcobucci/jwt": "<3.4",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^1.0|^2.0"
     },
     "require-dev": {
-        "illuminate/console": "^5.2|^6|^7|^8",
-        "illuminate/database": "^5.2|^6|^7|^8",
-        "illuminate/routing": "^5.2|^6|^7|^8",
+        "illuminate/console": "^5.2|^6|^7|^8|^9",
+        "illuminate/database": "^5.2|^6|^7|^8|^9",
+        "illuminate/routing": "^5.2|^6|^7|^8|^9",
         "mockery/mockery": ">=0.9.9",
         "phpunit/phpunit": "^8.5|^9.4",
         "yoast/phpunit-polyfills": "^0.2.0"


### PR DESCRIPTION
jwt-auth is not compatible with Laravel or Lumen version 9. That's why I've updated illuminate packages. 