### PR TITLE
Set leeway on Datetime Claims creation

### DIFF
--- a/src/Claims/DatetimeTrait.php
+++ b/src/Claims/DatetimeTrait.php
@@ -26,6 +26,19 @@ trait DatetimeTrait
     protected $leeway = 0;
 
     /**
+     * @param  mixed  $value
+     * @param  int  $leeway
+     *
+     * @return void
+     */
+    public function __construct($value, $leeway = 0)
+    {
+        $this->leeway = $leeway;
+
+        parent::__construct($value);
+    }
+
+    /**
      * Set the claim value, and call a validate method.
      *
      * @param  mixed  $value

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -76,11 +76,7 @@ class Factory
     public function get($name, $value)
     {
         if ($this->has($name)) {
-            $claim = new $this->classMap[$name]($value);
-
-            return method_exists($claim, 'setLeeway') ?
-                $claim->setLeeway($this->leeway) :
-                $claim;
+            return new $this->classMap[$name]($value, $this->leeway);
         }
 
         return new Custom($name, $value);

--- a/tests/Claims/FactoryTest.php
+++ b/tests/Claims/FactoryTest.php
@@ -58,6 +58,12 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
+    public function it_should_return_same_class_instance_when_setting_the_leeway()
+    {
+        $this->assertInstanceOf(Factory::class, $this->factory->setLeeway(5));
+    }
+
+    /** @test */
     public function it_should_get_a_defined_claim_instance_when_passing_a_name_and_value()
     {
         $this->assertInstanceOf(Subject::class, $this->factory->get('sub', 1));


### PR DESCRIPTION
Currently, the `leeway` property of Datetime claims is set after the instance creation, calling the relative setter method. This could cause validation errors inside the `validateCreate` method of the `IssuedAt` class, in the case where an instance gets created using a value from an existing token, due to the leeway not being considered.

This has caused some problems on one of our services that was running on a pool of different hosts which happened to have their system clocks out of sync. We solved the issue by fixing our NTP configurations, but we'd appreciate the `leeway` property to be correctly handled by the library.
The problem seems to be also mentioned [here](https://github.com/tymondesigns/jwt-auth/issues/2091).

We really appreciate your effort with this project and we hope you find this helpful. I'm always available if you need me to further expand on this.

Have a nice weekend!