### PR TITLE
Final public method for abstract class

### DIFF
--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -49,7 +49,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @throws \Tymon\JWTAuth\Exceptions\InvalidClaimException
      */
-    public function setValue($value)
+    final public function setValue($value)
     {
         $this->value = $this->validateCreate($value);
 
@@ -61,7 +61,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @return mixed
      */
-    public function getValue()
+    final public function getValue()
     {
         return $this->value;
     }
@@ -72,7 +72,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @param  string  $name
      * @return $this
      */
-    public function setName($name)
+    final public function setName($name)
     {
         $this->name = $name;
 
@@ -84,7 +84,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @return string
      */
-    public function getName()
+    final public function getName()
     {
         return $this->name;
     }
@@ -95,7 +95,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @param  mixed  $value
      * @return bool
      */
-    public function validateCreate($value)
+    final public function validateCreate($value)
     {
         return $value;
     }
@@ -105,7 +105,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @return bool
      */
-    public function validatePayload()
+    final public function validatePayload()
     {
         return $this->getValue();
     }
@@ -116,7 +116,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @param  int  $refreshTTL
      * @return bool
      */
-    public function validateRefresh($refreshTTL)
+    final public function validateRefresh($refreshTTL)
     {
         return $this->getValue();
     }
@@ -128,7 +128,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @param  bool  $strict
      * @return bool
      */
-    public function matches($value, $strict = true)
+    final public function matches($value, $strict = true)
     {
         return $strict ? $this->value === $value : $this->value == $value;
     }
@@ -139,7 +139,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @return array
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    final public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -149,7 +149,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @return array
      */
-    public function toArray()
+    final public function toArray()
     {
         return [$this->getName() => $this->getValue()];
     }
@@ -160,7 +160,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = JSON_UNESCAPED_SLASHES)
+    final public function toJson($options = JSON_UNESCAPED_SLASHES)
     {
         return json_encode($this->toArray(), $options);
     }

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -45,7 +45,7 @@ abstract class BaseMiddleware
      *
      * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
      */
-    public function checkForToken(Request $request)
+    final public function checkForToken(Request $request)
     {
         if (! $this->auth->parser()->setRequest($request)->hasToken()) {
             throw new UnauthorizedHttpException('jwt-auth', 'Token not provided');
@@ -60,7 +60,7 @@ abstract class BaseMiddleware
      *
      * @throws \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      */
-    public function authenticate(Request $request)
+    final public function authenticate(Request $request)
     {
         $this->checkForToken($request);
 

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -62,7 +62,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    final public function register()
     {
         $this->registerAliases();
 

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -67,7 +67,7 @@ abstract class Provider
      * @param  string  $algo
      * @return $this
      */
-    public function setAlgo($algo)
+    final public function setAlgo($algo)
     {
         $this->algo = $algo;
 
@@ -79,7 +79,7 @@ abstract class Provider
      *
      * @return string
      */
-    public function getAlgo()
+    final public function getAlgo()
     {
         return $this->algo;
     }
@@ -90,7 +90,7 @@ abstract class Provider
      * @param  string  $secret
      * @return $this
      */
-    public function setSecret($secret)
+    final public function setSecret($secret)
     {
         $this->secret = $secret;
 
@@ -102,7 +102,7 @@ abstract class Provider
      *
      * @return string
      */
-    public function getSecret()
+    final public function getSecret()
     {
         return $this->secret;
     }
@@ -113,7 +113,7 @@ abstract class Provider
      * @param  array  $keys
      * @return $this
      */
-    public function setKeys(array $keys)
+    final public function setKeys(array $keys)
     {
         $this->keys = $keys;
 
@@ -125,7 +125,7 @@ abstract class Provider
      *
      * @return array
      */
-    public function getKeys()
+    final public function getKeys()
     {
         return $this->keys;
     }
@@ -135,7 +135,7 @@ abstract class Provider
      *
      * @return string|null
      */
-    public function getPublicKey()
+    final public function getPublicKey()
     {
         return Arr::get($this->keys, 'public');
     }
@@ -145,7 +145,7 @@ abstract class Provider
      *
      * @return string|null
      */
-    public function getPrivateKey()
+    final public function getPrivateKey()
     {
         return Arr::get($this->keys, 'private');
     }
@@ -156,7 +156,7 @@ abstract class Provider
      *
      * @return string|null
      */
-    public function getPassphrase()
+    final public function getPassphrase()
     {
         return Arr::get($this->keys, 'passphrase');
     }

--- a/src/Validators/Validator.php
+++ b/src/Validators/Validator.php
@@ -25,7 +25,7 @@ abstract class Validator implements ValidatorContract
      * @param  array  $value
      * @return bool
      */
-    public function isValid($value)
+    final public function isValid($value)
     {
         try {
             $this->check($value);


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.