### PR TITLE
Get class to class keyword

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -262,7 +262,7 @@ class JWT
      */
     protected function hashSubjectModel($model)
     {
-        return sha1(is_object($model) ? get_class($model) : $model);
+        return sha1(is_object($model) ? $model::class : $model);
     }
 
     /**

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -274,7 +274,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     {
         if (preg_match('/get(.+)\b/i', $method, $matches)) {
             foreach ($this->claims as $claim) {
-                if (get_class($claim) === 'Tymon\\JWTAuth\\Claims\\'.$matches[1]) {
+                if ($claim::class === 'Tymon\\JWTAuth\\Claims\\'.$matches[1]) {
                     return $claim->getValue();
                 }
             }


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.