### PR TITLE
Explicit indirect variable

### DIFF
--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -103,7 +103,7 @@ class Factory
      */
     public function make($name)
     {
-        return $this->get($name, $this->$name());
+        return $this->get($name, $this->{$name}());
     }
 
     /**

--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -64,7 +64,7 @@ class LaravelServiceProvider extends AbstractServiceProvider
         $method = method_exists($router, 'aliasMiddleware') ? 'aliasMiddleware' : 'middleware';
 
         foreach ($this->middlewareAliases as $alias => $middleware) {
-            $router->$method($alias, $middleware);
+            $router->{$method}($alias, $middleware);
         }
     }
 }


### PR DESCRIPTION
Add curly braces to indirect variables to make them clear to understand.