### PR TITLE
Fix for issue #2209 | #2157 | #2205 | #2056 | #2116

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -123,7 +123,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth:api', ['except' => ['login']]);
+        $this->middleware('auth:api', ['except' => ['login', 'refresh']]);
     }
 
     /**


### PR DESCRIPTION
I can refresh a non-expired token normally, but when I try to refresh an expired token, I get a 401 response with the message "Unauthenticated", even if the token is within the allowed refresh time. 
fixed #2209 | #2157 | #2205 | #2056 | #2116 with: $this->middleware('auth:api', ['except' => ['login', 'refresh']]);