### PR TITLE
[fixing] - Remove path Token in Lcobucci\JWT\Builder for Laravel 5.7

### DIFF
--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -21,7 +21,7 @@ use Lcobucci\JWT\Signer\Ecdsa;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa;
-use Lcobucci\JWT\Token\Builder;
+use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Token\RegisteredClaims;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Tymon\JWTAuth\Contracts\Providers\JWT;


### PR DESCRIPTION
An error in methods  getBuilderFromClaims, 
`Return value of Tymon\JWTAuth\Providers\JWT\Lcobucci::getBuilderFromClaims() must be an instance of Lcobucci\JWT\Token\Builder, instance of Lcobucci\JWT\Builder returned`
![gambar](https://github.com/tymondesigns/jwt-auth/assets/60816261/313ac96b-e7df-4af2-bb64-77d017757e7b)

So i deleted Token path, from `use Lcobucci\JWT\Token\Builder;` to `use Lcobucci\JWT\Builder;` for fixing this error