### PR TITLE
Add support for Carbon 3.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/http": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
         "lcobucci/jwt": "^4.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^2.0|^3.0"
     },
     "require-dev": {
         "illuminate/console": "^9.0|^10.0|^11.0",


### PR DESCRIPTION
Adds `^3.0` version tag to the `nesbot/carbon` dependency on `composer.json` file, to fit on Laravel 11's dependencies.