### PR TITLE
Fixing getMinutesUntilExpired error

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -97,7 +97,7 @@ class Blacklist
         // get the latter of the two expiration dates and find
         // the number of minutes until the expiration date,
         // plus 1 minute to avoid overlap
-        return $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInMinutes(absolute: true);
+        return (int) $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInMinutes(absolute: true);
     }
 
     /**

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -97,7 +97,7 @@ class Blacklist
         // get the latter of the two expiration dates and find
         // the number of minutes until the expiration date,
         // plus 1 minute to avoid overlap
-        return $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes();
+        return $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInMinutes(absolute: true);
     }
 
     /**


### PR DESCRIPTION
The difference in minutes should be calculated with abs(), since `diffInMinutes` does: `$now - $this` (resulting in a negative value)

Fixes #2250 