### PR TITLE
Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must

### DIFF
--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -56,7 +56,7 @@ class Factory
     /**
      * Constructor.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
      * @return void
      */
     public function __construct(Request $request)
@@ -67,8 +67,8 @@ class Factory
     /**
      * Get the instance of the claim when passing the name and value.
      *
-     * @param  string  $name
-     * @param  mixed  $value
+     * @param string $name
+     * @param mixed $value
      * @return \Tymon\JWTAuth\Claims\Claim
      */
     public function get($name, $value)
@@ -87,7 +87,7 @@ class Factory
     /**
      * Check whether the claim exists.
      *
-     * @param  string  $name
+     * @param string $name
      * @return bool
      */
     public function has($name)
@@ -98,7 +98,7 @@ class Factory
     /**
      * Generate the initial value and return the Claim instance.
      *
-     * @param  string  $name
+     * @param string $name
      * @return \Tymon\JWTAuth\Claims\Claim
      */
     public function make($name)
@@ -159,8 +159,8 @@ class Factory
     /**
      * Add a new claim mapping.
      *
-     * @param  string  $name
-     * @param  string  $classPath
+     * @param string $name
+     * @param string $classPath
      * @return $this
      */
     public function extend($name, $classPath)
@@ -173,7 +173,7 @@ class Factory
     /**
      * Set the request instance.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
      * @return $this
      */
     public function setRequest(Request $request)
@@ -186,12 +186,12 @@ class Factory
     /**
      * Set the token ttl (in minutes).
      *
-     * @param  int  $ttl
+     * @param int $ttl
      * @return $this
      */
     public function setTTL($ttl)
     {
-        $this->ttl = $ttl;
+        $this->ttl = (int)$ttl;
 
         return $this;
     }
@@ -209,7 +209,7 @@ class Factory
     /**
      * Set the leeway in seconds.
      *
-     * @param  int  $leeway
+     * @param int $leeway
      * @return $this
      */
     public function setLeeway($leeway)


### PR DESCRIPTION
fix "Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given" error when read JWT_TTL from .env .