### PR TITLE
Adds number parsing to variables that comes from .env

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -279,8 +279,8 @@ abstract class AbstractServiceProvider extends ServiceProvider
         $this->app->singleton('tymon.jwt.blacklist', function ($app) {
             $instance = new Blacklist($app['tymon.jwt.provider.storage']);
 
-            return $instance->setGracePeriod($this->config('blacklist_grace_period'))
-                            ->setRefreshTTL($this->config('refresh_ttl'));
+            return $instance->setGracePeriod(intval($this->config('blacklist_grace_period')))
+                            ->setRefreshTTL(intval($this->config('refresh_ttl')));
         });
     }
 
@@ -293,7 +293,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     {
         $this->app->singleton('tymon.jwt.validators.payload', function () {
             return (new PayloadValidator)
-                ->setRefreshTTL($this->config('refresh_ttl'))
+                ->setRefreshTTL(intval($this->config('refresh_ttl')))
                 ->setRequiredClaims($this->config('required_claims'));
         });
     }
@@ -309,8 +309,8 @@ abstract class AbstractServiceProvider extends ServiceProvider
             $factory = new ClaimFactory($app['request']);
             $app->refresh('request', $factory, 'setRequest');
 
-            return $factory->setTTL($this->config('ttl'))
-                           ->setLeeway($this->config('leeway'));
+            return $factory->setTTL(intval($this->config('ttl')))
+                           ->setLeeway(intval($this->config('leeway')));
         });
     }
 


### PR DESCRIPTION
When you need to override a numeric variable through .env file (eg: `JWT_TTL`, `JWT_REFRESH_TTL`, `JWT_LEEWAY` or `JWT_BLACKLIST_GRACE_PERIOD`) a `TypeError` exception is thrown from Carbon due to value type error. It expects numeric values (int, float), but receives string ones.

![image](https://github.com/tymondesigns/jwt-auth/assets/2997670/73c22e80-9325-4791-8645-0b655b3143bb)

This PR adds `intval` parsing to those values on AbstractServiceProvider, to fix the value type that comes from .env.