### PR TITLE
SetSecret regenerates config with new secret in the Lcobucci provider

### DIFF
--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -278,4 +278,18 @@ class Lcobucci extends Provider implements JWT
     {
         return InMemory::plainText($contents, $passphrase);
     }
+
+    /**
+     * Set the secret used to sign the token.
+     *
+     * @param  string  $secret
+     * @return $this
+     */
+    public function setSecret($secret)
+    {
+        $this->secret = $secret;
+        $this->config = $this->buildConfig();
+
+        return $this;
+    }
 }

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -227,6 +227,26 @@ class LcobucciTest extends AbstractTestCase
         $this->assertSame($keys, $provider->getKeys());
     }
 
+    public function testItShouldThrowAExceptionWhenTheSecretHasBeenUpdatedAndAnOldTokenIsUsed()
+    {
+        $orignal_secret = 'OF8SQY475aF8uiRuWunK9ZO6VdZDBemk';
+        $new_secret = 'vsd1z800ApIihL6HVNyhbGLRyBLD74sZ';
+
+        $payload = ['sub' => '1', 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
+
+        $provider = $this->getProvider($orignal_secret, 'HS256', []);
+        $token = $provider->encode($payload);
+
+        $this->assertSame($payload, $provider->decode($token));
+
+        $provider->setSecret($new_secret);
+
+        $this->expectException(TokenInvalidException::class);
+        $this->expectExceptionMessage('Token Signature could not be verified.');
+
+        $provider->decode($token);
+    }
+
     public function getProvider($secret, $algo, array $keys = [])
     {
         return new Lcobucci($secret, $algo, $keys);


### PR DESCRIPTION
### Description

The secret that is set using the SetSecret method of the Lcobucci Provider is not used when encoding/decoding.
This is due to the secret only being applied when the config is generated when the provider is first being constructed.

To fix the issue, the config needs to be regenerated after the new Secret has been set.

Fixes #2258 #2234 #2215