### PR TITLE
Change the TTL type to an integer. Bug #2256

### DIFF
--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -191,7 +191,7 @@ class Factory
      */
     public function setTTL($ttl)
     {
-        $this->ttl = $ttl;
+        $this->ttl = (int) $ttl;
 
         return $this;
     }

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -214,7 +214,7 @@ class Factory
      */
     public function setLeeway($leeway)
     {
-        $this->leeway = $leeway;
+        $this->leeway = (int) $leeway;
 
         return $this;
     }


### PR DESCRIPTION
Fix permanently bug reported in https://github.com/tymondesigns/jwt-auth/issues/2256 
changing Tymon\JWTAuth\Claims\Factory setTTL method


Fix permanently bug reported in https://github.com/tymondesigns/jwt-auth/issues/2264
changing Tymon\JWTAuth\Claims\Factory setLeeway method

