### PR TITLE
Add support for PHP 8.4 and Carbon 3

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
         laravel: [9.*, 10.*, 11.*]
         os: [ubuntu-latest]
         coverage: [none]

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -97,7 +97,14 @@ class Blacklist
         // get the latter of the two expiration dates and find
         // the number of minutes until the expiration date,
         // plus 1 minute to avoid overlap
-        return $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes();
+        $minutes = $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes();
+
+        // if Carbon 3
+        if (is_float($minutes)) {
+            return (int) round(abs($minutes));
+        }
+
+        return $minutes;
     }
 
     /**

--- a/src/Claims/Collection.php
+++ b/src/Claims/Collection.php
@@ -31,11 +31,11 @@ class Collection extends IlluminateCollection
      * Get a Claim instance by it's unique name.
      *
      * @param  string  $name
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  mixed  $default
      * @return \Tymon\JWTAuth\Claims\Claim
      */
-    public function getByClaimName($name, callable $callback = null, $default = null)
+    public function getByClaimName($name, ?callable $callback = null, $default = null)
     {
         return $this->filter(function (Claim $claim) use ($name) {
             return $claim->getName() === $name;

--- a/src/Exceptions/InvalidClaimException.php
+++ b/src/Exceptions/InvalidClaimException.php
@@ -24,7 +24,7 @@ class InvalidClaimException extends JWTException
      * @param  \Exception|null  $previous
      * @return void
      */
-    public function __construct(Claim $claim, $code = 0, Exception $previous = null)
+    public function __construct(Claim $claim, $code = 0, ?Exception $previous = null)
     {
         parent::__construct('Invalid value provided for claim ['.$claim->getName().']', $code, $previous);
     }


### PR DESCRIPTION
This PR adds support for PHP 8.4 as well as fixing a bug introduced by https://github.com/tymondesigns/jwt-auth/pull/2247.

See https://github.com/tymondesigns/jwt-auth/pull/2247#issuecomment-2017414717