### PR TITLE
[FIX] deprecated diff function on Carbon 2x, 3x

### DIFF
--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -97,7 +97,13 @@ class Blacklist
         // get the latter of the two expiration dates and find
         // the number of minutes until the expiration date,
         // plus 1 minute to avoid overlap
-        $minutes = $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes();
+        $adjustedExpiration = $exp->max($iat->addMinutes($this->refreshTTL))->addMinute();
+
+        if (method_exists($adjustedExpiration, 'diffInRealMinutes')) {
+            $minutes = $adjustedExpiration->diffInRealMinutes();
+        } else {
+            $minutes = $adjustedExpiration->diffInMinutes();
+        }
 
         // if Carbon 3
         if (is_float($minutes)) {


### PR DESCRIPTION
While upgrading my project from Laravel 7.x (PHP 7.4.33) to Laravel 11.x (PHP 8.3), I encountered a warning from Carbon when using this package in a logout use case. After investigating, I traced the issue to the changes outlined in Carbon's cleanup article: [♻️ Cleanup diffIn* diffInReal* floatDiffIn* floatDiffInReal*](https://github.com/briannesbitt/Carbon/issues/2119). This warning stems from deprecated or adjusted methods in newer Carbon versions, which are now stricter with PHP 8.3 compatibility.

To address this, I’m excited to submit this pull request. It resolves the warning by ensuring compatibility with the updated Carbon behavior, making the logout functionality seamless and future-proof. This fix not only eliminates the alert but also enhances the package’s reliability for other users upgrading to Laravel 11.x. I’d be honored to contribute this improvement to the community—thanks for considering it!