### PR TITLE
[feat] Dynamic timezone handling in Utils class

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -16,13 +16,25 @@ use Carbon\Carbon;
 class Utils
 {
     /**
+     * Get the timezone from Carbon.
+     *
+     * @return string
+     */
+    protected static function getTimezone()
+    {
+        $tz = Carbon::now()->getTimezone()->getName();
+
+        return in_array($tz, timezone_identifiers_list()) ? $tz : 'UTC';
+    }
+
+    /**
      * Get the Carbon instance for the current time.
      *
      * @return \Carbon\Carbon
      */
     public static function now()
     {
-        return Carbon::now('UTC');
+        return Carbon::now(static::getTimezone());
     }
 
     /**
@@ -33,7 +45,7 @@ class Utils
      */
     public static function timestamp($timestamp)
     {
-        return Carbon::createFromTimestampUTC($timestamp)->timezone('UTC');
+        return Carbon::createFromTimestampUTC($timestamp)->timezone(static::getTimezone());
     }
 
     /**


### PR DESCRIPTION
- Introduced `timezone()` method to dynamically resolve timezone using `Carbon::now()`.
- Replaced all hardcoded `UTC` values with dynamic timezone.
- Ensures better compatibility with host system's timezone settings.