### PR TITLE
chore: Inherit Doc

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -64,9 +64,7 @@ class JWTGuard implements Guard
     }
 
     /**
-     * Get the currently authenticated user.
-     *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * {@inheritDoc}
      */
     public function user()
     {


### PR DESCRIPTION
When using VSCode with the [laravel/vs-code-extension](https://github.com/laravel/vs-code-extension) plugin installed, the plugin automatically determines and modifies the return value of Auth::user() to the corresponding model (`\App\Models\User`)

However, `\Tymon\JWTAuth\JWTGuard::user()` duplicates the return value, causing the return value modified by the plug-in to not take effect, so this PR modifies the comment of the user() method so that it inherits from the document.

#### laravel/vs-code-extension added file
```php
// vendor/_laravel_ide/_auth.php
<?php

namespace Illuminate\Contracts\Auth;

interface Guard
{
    /**
     * @return \App\Models\User|null
     */
    public function user();
}
```

#### Before modification
<img width="702" height="371" alt="image" src="https://github.com/user-attachments/assets/e8e0c784-af3d-41c3-a9c2-d771cbad55fe" />

#### After modification
<img width="644" height="367" alt="image" src="https://github.com/user-attachments/assets/82622744-fcad-4ff4-a2fc-df851be35da3" />
